### PR TITLE
Feature/revsdl 847 change primary notify

### DIFF
--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -497,8 +497,6 @@ private:
    */
   std::map<std::string, std::string> app_to_device_link_;
 
-  application_manager::TypeAccess access_;
-
   // Lock for app to device list
   sync_primitives::Lock app_to_device_link_lock_;
 

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -1329,17 +1329,31 @@ void PolicyHandler::ResetAccess(const std::string& group_name,
 
 void PolicyHandler::SetPrimaryDevice(const PTString& dev_id) {
   POLICY_LIB_CHECK_VOID();
+  PTString old_dev_id = policy_manager_->PrimaryDevice();
   policy_manager_->SetPrimaryDevice(dev_id);
+
+  connection_handler::DeviceHandle old_device_handle;
+    ApplicationManagerImpl::instance()->connection_handler()
+        ->GetDeviceID(old_dev_id, &old_device_handle);
 
   connection_handler::DeviceHandle device_handle;
   ApplicationManagerImpl::instance()->connection_handler()
       ->GetDeviceID(dev_id, &device_handle);
 
+  LOG4CXX_DEBUG(
+      logger_,
+      "Old: " << old_dev_id << "(" << old_device_handle << ")" <<
+      "New: " << dev_id << "(" << device_handle << ")");
   ApplicationManagerImpl::ApplicationListAccessor accessor;
   for (ApplicationManagerImpl::ApplictionSetConstIt i = accessor.begin();
       i != accessor.end(); ++i) {
     const ApplicationSharedPtr app = *i;
-    if (app->device() == device_handle) {
+    LOG4CXX_DEBUG(logger_,
+                  "Item: " << app->device() << " - " << app->mobile_app_id());
+    if (app->device() == device_handle || app->device() == old_device_handle) {
+      LOG4CXX_DEBUG(
+          logger_,
+          "Send notify " << app->device() << " - " << app->mobile_app_id());
       policy_manager_->SendNotificationOnPermissionsUpdated(app->mobile_app_id());
     }
   }

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -1330,6 +1330,19 @@ void PolicyHandler::ResetAccess(const std::string& group_name,
 void PolicyHandler::SetPrimaryDevice(const PTString& dev_id) {
   POLICY_LIB_CHECK_VOID();
   policy_manager_->SetPrimaryDevice(dev_id);
+
+  connection_handler::DeviceHandle device_handle;
+  ApplicationManagerImpl::instance()->connection_handler()
+      ->GetDeviceID(dev_id, &device_handle);
+
+  ApplicationManagerImpl::ApplicationListAccessor accessor;
+  for (ApplicationManagerImpl::ApplictionSetConstIt i = accessor.begin();
+      i != accessor.end(); ++i) {
+    const ApplicationSharedPtr app = *i;
+    if (app->device() == device_handle) {
+      policy_manager_->SendNotificationOnPermissionsUpdated(app->mobile_app_id());
+    }
+  }
 }
 
 void PolicyHandler::SetRemoteControl(bool enabled) {

--- a/src/components/policy/src/policy/include/policy/access_remote.h
+++ b/src/components/policy/src/policy/include/policy/access_remote.h
@@ -121,6 +121,12 @@ class AccessRemote {
   virtual void SetPrimaryDevice(const PTString& dev_id) = 0;
 
   /**
+   * Gets current primary device
+   * @return ID device
+   */
+  virtual PTString PrimaryDevice() const = 0;
+
+  /**
    * Checks passenger can control of the requested zone without asking driver
    * @param seat seat of passenger
    * @param zone requested zone to control

--- a/src/components/policy/src/policy/include/policy/access_remote.h
+++ b/src/components/policy/src/policy/include/policy/access_remote.h
@@ -179,8 +179,8 @@ class AccessRemote {
    * @param app_id ID application
    * @param hmi_types list of HMI types
    */
-  virtual void SetDefaultHmiTypes(
-      const std::string& app_id, const std::vector<int>& hmi_types) = 0;
+  virtual void SetDefaultHmiTypes(const std::string& app_id,
+                                  const std::vector<int>& hmi_types) = 0;
 
   /**
    * Gets groups
@@ -188,8 +188,19 @@ class AccessRemote {
    * @param app_id ID application
    * @return list of groups
    */
-  virtual const policy_table::Strings& GetGroups(
-      const PTString& device_id, const PTString& app_id) = 0;
+  virtual const policy_table::Strings& GetGroups(const PTString& device_id,
+                                                 const PTString& app_id) = 0;
+
+  /**
+   * Gets permissions for application
+   * @param device_id
+   * @param app_id
+   * @param group_types
+   * @return true if success
+   */
+  virtual bool GetPermissionsForApp(const std::string &device_id,
+                                    const std::string &app_id,
+                                    FunctionalIdType& group_types) = 0;
 };
 
 }  // namespace policy

--- a/src/components/policy/src/policy/include/policy/access_remote_impl.h
+++ b/src/components/policy/src/policy/include/policy/access_remote_impl.h
@@ -66,6 +66,7 @@ class AccessRemoteImpl : public AccessRemote {
 
   virtual bool IsPrimaryDevice(const PTString& dev_id) const;
   virtual void SetPrimaryDevice(const PTString& dev_id);
+  virtual PTString PrimaryDevice() const;
   virtual bool IsPassengerZone(const SeatLocation& seat,
                                const SeatLocation& zone) const;
 

--- a/src/components/policy/src/policy/include/policy/access_remote_impl.h
+++ b/src/components/policy/src/policy/include/policy/access_remote_impl.h
@@ -80,6 +80,9 @@ class AccessRemoteImpl : public AccessRemote {
                                   const std::vector<int>& hmi_types);
   virtual const policy_table::Strings& GetGroups(const PTString& device_id,
                                                  const PTString& app_id);
+  virtual bool GetPermissionsForApp(const std::string &device_id,
+                                    const std::string &app_id,
+                                    FunctionalIdType& group_types);
 
  private:
   typedef std::map<Subject, TypeAccess> AccessControlRow;

--- a/src/components/policy/src/policy/include/policy/access_remote_impl.h
+++ b/src/components/policy/src/policy/include/policy/access_remote_impl.h
@@ -90,7 +90,8 @@ class AccessRemoteImpl : public AccessRemote {
   typedef std::map<std::string, policy_table::AppHMITypes> HMIList;
   inline void set_enabled(bool value);
   const policy_table::AppHMITypes& HmiTypes(const std::string& app_id);
-
+  void GetGroupsIds(const std::string &device_id, const std::string &app_id,
+                    FunctionalGroupIDs& grops_ids);
   utils::SharedPtr<CacheManager> cache_;
   PTString primary_device_;
   bool enabled_;

--- a/src/components/policy/src/policy/include/policy/policy_manager.h
+++ b/src/components/policy/src/policy/include/policy/policy_manager.h
@@ -443,6 +443,12 @@ class PolicyManager : public usage_statistics::StatisticsManager {
     virtual void SetPrimaryDevice(const PTString& dev_id) = 0;
 
     /**
+     * Gets current primary device
+     * @return ID device
+     */
+    virtual PTString PrimaryDevice() const = 0;
+
+    /**
      * Sets mode of remote control (on/off)
      * @param enabled true if remote control is turned on
      */

--- a/src/components/policy/src/policy/include/policy/policy_manager_impl.h
+++ b/src/components/policy/src/policy/include/policy/policy_manager_impl.h
@@ -179,6 +179,7 @@ class PolicyManagerImpl : public PolicyManager {
     virtual void ResetAccess(const PTString& group_name,
                              const SeatLocation zone);
     virtual void SetPrimaryDevice(const PTString& dev_id);
+    virtual PTString PrimaryDevice() const;
     virtual void SetRemoteControl(bool enabled);
 #endif  // SDL_REMOTE_CONTROL
 

--- a/src/components/policy/src/policy/src/access_remote_impl.cc
+++ b/src/components/policy/src/policy/src/access_remote_impl.cc
@@ -236,6 +236,10 @@ void AccessRemoteImpl::SetPrimaryDevice(const PTString& dev_id) {
   cache_->Backup();
 }
 
+PTString AccessRemoteImpl::PrimaryDevice() const {
+  return primary_device_;
+}
+
 void AccessRemoteImpl::Enable() {
   LOG4CXX_AUTO_TRACE(logger_);
   set_enabled(true);

--- a/src/components/policy/src/policy/src/policy_manager_impl.cc
+++ b/src/components/policy/src/policy/src/policy_manager_impl.cc
@@ -340,8 +340,17 @@ void PolicyManagerImpl::SendNotificationOnPermissionsUpdated(
   std::string default_hmi;
   default_hmi = "NONE";
 
+#ifdef SDL_REMOTE_CONTROL
+  if (access_remote_->IsPrimaryDevice(device_id)) {
+    listener()->OnPermissionsUpdated(application_id, notification_data);
+  } else {
+    listener()->OnPermissionsUpdated(application_id, notification_data,
+                                     default_hmi);
+  }
+#else
   listener()->OnPermissionsUpdated(application_id, notification_data,
-                                   default_hmi);
+                                     default_hmi);
+#endif  // SDL_REMOTE_CONTROL
 }
 
 bool PolicyManagerImpl::CleanupUnpairedDevices() {
@@ -997,6 +1006,11 @@ void PolicyManagerImpl::ResetAccess(const PTString& group_name,
 void PolicyManagerImpl::SetPrimaryDevice(const PTString& dev_id) {
   LOG4CXX_AUTO_TRACE(logger_);
   access_remote_->SetPrimaryDevice(dev_id);
+}
+
+PTString PolicyManagerImpl::PrimaryDevice() const {
+  LOG4CXX_AUTO_TRACE(logger_);
+  return access_remote_->PrimaryDevice();
 }
 
 void PolicyManagerImpl::SetRemoteControl(bool enabled) {

--- a/src/components/policy/src/policy/src/policy_manager_impl.cc
+++ b/src/components/policy/src/policy/src/policy_manager_impl.cc
@@ -550,7 +550,7 @@ void PolicyManagerImpl::GetPermissionsForApp(
   LOG4CXX_INFO(logger_, "GetPermissionsForApp");
 
   if (!cache_->IsApplicationRepresented(policy_app_id)) {
-    LOG4CXX_WARN(logger_, "Application " << app_id << " isn't exist");
+    LOG4CXX_WARN(logger_, "Application " << policy_app_id << " isn't exist");
     return;
   }
 
@@ -568,14 +568,14 @@ void PolicyManagerImpl::GetPermissionsForApp(
 
   FunctionalIdType group_types;
 #ifdef REMOTE_CONTROL
-  bool ret = remote_control->GetPermissionsForApp(device_id, app_id_to_check,
+  bool ret = remote_control->GetPermissionsForApp(device_id, policy_app_id,
                                                   group_types);
 #else
   bool ret = cache_->GetPermissionsForApp(device_id, app_id_to_check,
                                           group_types);
 #endif  // REMOTE_CONTROL
 
-  if (!ret)
+  if (!ret) {
     LOG4CXX_WARN(logger_, "Can't get user permissions for app "
                  << policy_app_id);
     return;

--- a/src/components/policy/src/policy/src/policy_manager_impl.cc
+++ b/src/components/policy/src/policy/src/policy_manager_impl.cc
@@ -278,6 +278,13 @@ void PolicyManagerImpl::CheckPermissions(const PTString& app_id,
                                           const PTString& rpc,
                                           const RPCParams& rpc_params,
                                           CheckPermissionResult& result) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  if (!cache_->IsApplicationRepresented(app_id)) {
+    LOG4CXX_WARN(logger_, "Application " << app_id << " isn't exist");
+    return;
+  }
+
   LOG4CXX_INFO(
     logger_,
     "CheckPermissions for " << app_id << " and rpc " << rpc << " for "
@@ -541,6 +548,12 @@ void PolicyManagerImpl::GetPermissionsForApp(
   const std::string& device_id, const std::string& policy_app_id,
   std::vector<FunctionalGroupPermission>& permissions) {
   LOG4CXX_INFO(logger_, "GetPermissionsForApp");
+
+  if (!cache_->IsApplicationRepresented(policy_app_id)) {
+    LOG4CXX_WARN(logger_, "Application " << app_id << " isn't exist");
+    return;
+  }
+
   std::string app_id_to_check = policy_app_id;
 
   bool allowed_by_default = false;
@@ -554,8 +567,15 @@ void PolicyManagerImpl::GetPermissionsForApp(
   }
 
   FunctionalIdType group_types;
-  if (!cache_->GetPermissionsForApp(device_id, app_id_to_check,
-                                        group_types)) {
+#ifdef REMOTE_CONTROL
+  bool ret = remote_control->GetPermissionsForApp(device_id, app_id_to_check,
+                                                  group_types);
+#else
+  bool ret = cache_->GetPermissionsForApp(device_id, app_id_to_check,
+                                          group_types);
+#endif  // REMOTE_CONTROL
+
+  if (!ret)
     LOG4CXX_WARN(logger_, "Can't get user permissions for app "
                  << policy_app_id);
     return;

--- a/src/components/policy/test/include/mock_access_remote.h
+++ b/src/components/policy/test/include/mock_access_remote.h
@@ -59,6 +59,7 @@ class MockAccessRemote : public AccessRemote {
       bool(const PTString& dev_id));
   MOCK_METHOD1(SetPrimaryDevice,
       void(const PTString& dev_id));
+  MOCK_CONST_METHOD0(PrimaryDevice, PTString());
   MOCK_CONST_METHOD2(IsPassengerZone,
       bool(const SeatLocation& seat, const SeatLocation& zone));
   MOCK_METHOD2(Allow,

--- a/src/components/policy/test/include/mock_access_remote.h
+++ b/src/components/policy/test/include/mock_access_remote.h
@@ -77,6 +77,8 @@ class MockAccessRemote : public AccessRemote {
       void(const std::string& app_id, const std::vector<int>& hmi_types));
   MOCK_METHOD2(GetGroups,
       const policy_table::Strings&(const PTString& device_id, const PTString& app_id));
+  MOCK_METHOD3(GetPermissionsForApp,
+      bool (const std::string& device_id, const std::string& app_id, policy::FunctionalIdType& group_types));
 };
 
 }  // namespace policy


### PR DESCRIPTION
Implemented:
1 In case the device is set as 'primary' (either by default or by user's selection), R-SDL must assign "groups_primaryRC" permissions from appropriate policies to each remote-control app from this device.
2 In case the device is set as 'non-primary' (either by default or by user's selection), R-SDL must assign "groups_nonPrimaryRC" permissions from appropriate policies to each remote-control app from this device.
4 In case the device's state is changed from "non-primary" to "primary", all remote-control applications must remain in the same HMILevel as they were.
5 In case the device's "primary"/"non-primary" state is either changed from one to another or initially set, Rev-SDL must notify each app registered from such device via OnPermissionsChange notification about changed policy permission. **but it is blocked by policy manager for non-primary device**