### PR TITLE
REVSDL-899: Fix checking passenger zone

### DIFF
--- a/src/components/application_manager/include/application_manager/core_service.h
+++ b/src/components/application_manager/include/application_manager/core_service.h
@@ -80,7 +80,6 @@ class CoreService : public Service {
   virtual TypeAccess CheckAccess(const ApplicationId& app_id,
                                  const PluginFunctionID& function_id,
                                  const std::vector<std::string>& params,
-                                 const SeatLocation& seat,
                                  const SeatLocation& zone);
 
   /**

--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -107,7 +107,6 @@ class PolicyHandler :
   application_manager::TypeAccess CheckAccess(const PTString& app_id,
                                               const PTString& rpc,
                                               const RemoteControlParams& params,
-                                              const SeatLocation& seat,
                                               const SeatLocation& zone);
 
   /**

--- a/src/components/application_manager/include/application_manager/service.h
+++ b/src/components/application_manager/include/application_manager/service.h
@@ -79,7 +79,6 @@ class Service {
   virtual TypeAccess CheckAccess(const ApplicationId& app_id,
                                  const PluginFunctionID& function_id,
                                  const std::vector<std::string>& params,
-                                 const SeatLocation& seat,
                                  const SeatLocation& zone) = 0;
 
   /**

--- a/src/components/application_manager/src/core_service.cc
+++ b/src/components/application_manager/src/core_service.cc
@@ -85,14 +85,13 @@ mobile_apis::Result::eType CoreService::CheckPolicyPermissions(MessagePtr msg) {
 TypeAccess CoreService::CheckAccess(const ApplicationId& app_id,
                                     const PluginFunctionID& function_id,
                                     const std::vector<std::string>& params,
-                                    const SeatLocation& seat,
                                     const SeatLocation& zone) {
 #ifdef SDL_REMOTE_CONTROL
   ApplicationSharedPtr app = GetApplication(app_id);
   if (app) {
 
     return policy::PolicyHandler::instance()->CheckAccess(
-        app->mobile_app_id(), function_id, params, seat, zone);
+        app->mobile_app_id(), function_id, params, zone);
   }
 #endif  // SDL_REMOTE_CONTROL
   return kNone;

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -1300,11 +1300,10 @@ void PolicyHandler::Add(const std::string& app_id,
 #ifdef SDL_REMOTE_CONTROL
 application_manager::TypeAccess PolicyHandler::CheckAccess(
     const PTString& app_id, const PTString& rpc,
-    const RemoteControlParams& params, const SeatLocation& seat,
-    const SeatLocation& zone) {
+    const RemoteControlParams& params, const SeatLocation& zone) {
   POLICY_LIB_CHECK(application_manager::TypeAccess::kNone);
   policy::TypeAccess access = policy_manager_->CheckAccess(app_id, rpc, params,
-                                                           seat, zone);
+                                                           zone);
   return ConvertTypeAccess(access);
 }
 

--- a/src/components/can_cooperation/src/command/base_command_notification.cc
+++ b/src/components/can_cooperation/src/command/base_command_notification.cc
@@ -99,18 +99,11 @@ void BaseCommandNotification::Run() {
   mobile_apis::Result::eType permission =
       service_->CheckPolicyPermissions(message_);
 
-  CANAppExtensionPtr extension = GetAppExtension(app);
-  SeatLocation seat;
-  if (extension) {
-    seat = extension->seat();
-  }
-
-  seat = 0;
-  // TODO(KKolodiy): get zone and params
+  // TODO(KKolodiy): get zone and params from message
   SeatLocation zone = 10;
   std::vector<std::string> params;
   application_manager::TypeAccess access = service_->CheckAccess(
-      app->app_id(), message_->function_name(), params, seat, zone);
+      app->app_id(), message_->function_name(), params, zone);
 
   if (permission == mobile_apis::Result::eType::SUCCESS &&
       access == application_manager::TypeAccess::kAllowed) {

--- a/src/components/can_cooperation/src/command/base_command_request.cc
+++ b/src/components/can_cooperation/src/command/base_command_request.cc
@@ -314,17 +314,11 @@ void BaseCommandRequest::Run() {
   }
 
   CANAppExtensionPtr extension = GetAppExtension(app_);
-  SeatLocation seat;
-  if (extension) {
-    seat = extension->seat();
-  }
-
-  seat = 0;
-  // TODO(KKolodiy): get zone and params
+  // TODO(KKolodiy): get zone and params from message
   SeatLocation zone = 10;
   std::vector<std::string> params;
   application_manager::TypeAccess access = service_->CheckAccess(
-      app_->app_id(), message_->function_name(), params, seat, zone);
+      app_->app_id(), message_->function_name(), params, zone);
 
   switch (access) {
     case application_manager::kAllowed:

--- a/src/components/can_cooperation/test/include/mock_service.h
+++ b/src/components/can_cooperation/test/include/mock_service.h
@@ -53,11 +53,10 @@ class MockService : public Service {
       std::vector<ApplicationSharedPtr>(AppExtensionUID uid));
   MOCK_METHOD1(SubscribeToHMINotification,
       void(const std::string& hmi_notification));
-  MOCK_METHOD5(CheckAccess,
+  MOCK_METHOD4(CheckAccess,
       TypeAccess(const ApplicationId& app_id,
           const PluginFunctionID& function_id,
           const std::vector<std::string>& params,
-          const SeatLocation& seat,
           const SeatLocation& zone));
   MOCK_METHOD4(SetAccess,
       void(const ApplicationId& app_id,

--- a/src/components/functional_module/test/include/mock_service.h
+++ b/src/components/functional_module/test/include/mock_service.h
@@ -53,11 +53,10 @@ class MockService : public Service {
       std::vector<ApplicationSharedPtr>(AppExtensionUID));
   MOCK_METHOD1(SubscribeToHMINotification,
       void(const std::string& hmi_notification));
-  MOCK_METHOD5(CheckAccess,
+  MOCK_METHOD4(CheckAccess,
       TypeAccess(const ApplicationId& app_id,
           const PluginFunctionID& function_id,
           const std::vector<std::string>& params,
-          const SeatLocation& seat,
           const SeatLocation& zone));
   MOCK_METHOD4(SetAccess,
       void(const ApplicationId& app_id,

--- a/src/components/policy/src/policy/include/policy/access_remote.h
+++ b/src/components/policy/src/policy/include/policy/access_remote.h
@@ -129,15 +129,6 @@ class AccessRemote {
   virtual PTString PrimaryDevice() const = 0;
 
   /**
-   * Checks passenger can control of the requested zone without asking driver
-   * @param seat seat of passenger
-   * @param zone requested zone to control
-   * @return true if passenger can control this zone
-   */
-  virtual bool IsPassengerZone(const SeatLocation& seat,
-                               const SeatLocation& zone) const = 0;
-
-  /**
    * Allows access subject to object
    * @param who subject is dev_id and app_id
    * @param what object is group_id and zone

--- a/src/components/policy/src/policy/include/policy/access_remote_impl.h
+++ b/src/components/policy/src/policy/include/policy/access_remote_impl.h
@@ -67,8 +67,6 @@ class AccessRemoteImpl : public AccessRemote {
   virtual bool IsPrimaryDevice(const PTString& dev_id) const;
   virtual void SetPrimaryDevice(const PTString& dev_id, const PTString& input);
   virtual PTString PrimaryDevice() const;  
-  virtual bool IsPassengerZone(const SeatLocation& seat,
-                               const SeatLocation& zone) const;
 
   virtual void Allow(const Subject& who, const Object& what);
   virtual void Deny(const Subject& who, const Object& what);

--- a/src/components/policy/src/policy/include/policy/policy_manager.h
+++ b/src/components/policy/src/policy/include/policy/policy_manager.h
@@ -409,7 +409,6 @@ class PolicyManager : public usage_statistics::StatisticsManager {
      */
     virtual TypeAccess CheckAccess(const PTString& app_id, const PTString& rpc,
                                    const RemoteControlParams& params,
-                                   const SeatLocation& seat,
                                    const SeatLocation& zone) = 0;
 
     /**

--- a/src/components/policy/src/policy/include/policy/policy_manager_impl.h
+++ b/src/components/policy/src/policy/include/policy/policy_manager_impl.h
@@ -171,7 +171,6 @@ class PolicyManagerImpl : public PolicyManager {
 #ifdef SDL_REMOTE_CONTROL
     virtual TypeAccess CheckAccess(const PTString& app_id, const PTString& rpc,
                                    const RemoteControlParams& params,
-                                   const SeatLocation& seat,
                                    const SeatLocation& zone);
     virtual void SetAccess(const PTString& app_id, const PTString& group_name,
                            const SeatLocation zone, bool allowed);

--- a/src/components/policy/src/policy/src/access_remote_impl.cc
+++ b/src/components/policy/src/policy/src/access_remote_impl.cc
@@ -178,12 +178,6 @@ bool AccessRemoteImpl::IsPrimaryDevice(const PTString& dev_id) const {
   return primary_device_ == dev_id;
 }
 
-bool AccessRemoteImpl::IsPassengerZone(const SeatLocation& seat,
-                                       const SeatLocation& zone) const {
-  LOG4CXX_AUTO_TRACE(logger_);
-  return seat == zone;
-}
-
 TypeAccess AccessRemoteImpl::Check(const Subject& who,
                                    const Object& what) const {
   LOG4CXX_AUTO_TRACE(logger_);

--- a/src/components/policy/test/policy_manager_impl_stress_test.cc
+++ b/src/components/policy/test/policy_manager_impl_stress_test.cc
@@ -279,7 +279,9 @@ void PolicyManagerImplStressTest::CreateTable(std::ofstream& ofs) {
 TEST_F(PolicyManagerImplStressTest, OneCheck_AppAndFunctuionExisting_RpcAllowed) {
   ::policy::RPCParams input_params;
   ::policy::CheckPermissionResult output;
+#ifdef SDL_REMOTE_CONTROL
   EXPECT_CALL(*mock_listener, OnCurrentDeviceIdUpdateRequired("2"));
+#endif  // SDL_REMOTE_CONTROL
   manager->CheckPermissions("2", "FULL", "Func-0", input_params, output);
   EXPECT_EQ(::policy::kRpcAllowed, output.hmi_level_permitted);
 }
@@ -287,7 +289,9 @@ TEST_F(PolicyManagerImplStressTest, OneCheck_AppAndFunctuionExisting_RpcAllowed)
 TEST_F(PolicyManagerImplStressTest, NoApp_AppDoesNotExisted_RpcDissallowed) {
   ::policy::RPCParams input_params;
   ::policy::CheckPermissionResult output;
-  EXPECT_CALL(*mock_listener, OnCurrentDeviceIdUpdateRequired("1500"));
+#ifdef SDL_REMOTE_CONTROL
+  EXPECT_CALL(*mock_listener, OnCurrentDeviceIdUpdateRequired("1500")).Times(0);
+#endif  // SDL_REMOTE_CONTROL
   manager->CheckPermissions("1500", "FULL", "Func-88", input_params, output);
   EXPECT_EQ(::policy::kRpcDisallowed, output.hmi_level_permitted);
 }
@@ -295,7 +299,9 @@ TEST_F(PolicyManagerImplStressTest, NoApp_AppDoesNotExisted_RpcDissallowed) {
 TEST_F(PolicyManagerImplStressTest, NoFunc_FuncDoesNotExisted_RpcDissallowed) {
   ::policy::RPCParams input_params;
   ::policy::CheckPermissionResult output;
+#ifdef SDL_REMOTE_CONTROL
   EXPECT_CALL(*mock_listener, OnCurrentDeviceIdUpdateRequired("2"));
+#endif  // SDL_REMOTE_CONTROL
   manager->CheckPermissions("2", "FULL", "Func-1500", input_params, output);
   EXPECT_EQ(::policy::kRpcDisallowed, output.hmi_level_permitted);
 }
@@ -303,7 +309,9 @@ TEST_F(PolicyManagerImplStressTest, NoFunc_FuncDoesNotExisted_RpcDissallowed) {
 TEST_F(PolicyManagerImplStressTest, NoHmi_HMIInLevelNone_RpcDissallowed) {
   ::policy::RPCParams input_params;
   ::policy::CheckPermissionResult output;
+#ifdef SDL_REMOTE_CONTROL
   EXPECT_CALL(*mock_listener, OnCurrentDeviceIdUpdateRequired("2"));
+#endif  // SDL_REMOTE_CONTROL
   manager->CheckPermissions("2", "NONE", "Func-88", input_params, output);
   EXPECT_EQ(::policy::kRpcDisallowed, output.hmi_level_permitted);
 }
@@ -313,8 +321,10 @@ TEST_F(PolicyManagerImplStressTest, FewChecks_CheckSeveralFunctions) {
   std::stringstream ss;
   int app, func;
   std::string app_number, func_number;
+#ifdef SDL_REMOTE_CONTROL
   EXPECT_CALL(*mock_listener, OnCurrentDeviceIdUpdateRequired(_)).Times(
       kNumberOfCheckings);
+#endif  // SDL_REMOTE_CONTROL
   for (int i = 0; i < kNumberOfCheckings; ++i) {
     app = rand() % kNumberApps;
     func = rand() % kNumberFuncs;


### PR DESCRIPTION
Removed checking current position of passenger with requested zone. It isn't needed.