### PR TITLE
Feature/revsdl 901 disable remote control

### DIFF
--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -1363,6 +1363,25 @@ void PolicyHandler::SetPrimaryDevice(const PTString& dev_id,
 void PolicyHandler::SetRemoteControl(bool enabled) {
   POLICY_LIB_CHECK_VOID();
   policy_manager_->SetRemoteControl(enabled);
+
+  PTString device_id = policy_manager_->PrimaryDevice();
+  connection_handler::DeviceHandle device_handle;
+    ApplicationManagerImpl::instance()->connection_handler()
+        ->GetDeviceID(device_id, &device_handle);
+
+  ApplicationManagerImpl::ApplicationListAccessor accessor;
+  for (ApplicationManagerImpl::ApplictionSetConstIt i = accessor.begin();
+      i != accessor.end(); ++i) {
+    const ApplicationSharedPtr app = *i;
+    LOG4CXX_DEBUG(logger_,
+                  "Item: " << app->device() << " - " << app->mobile_app_id());
+    if (app->device() != device_handle) {
+      LOG4CXX_DEBUG(
+          logger_,
+          "Send notify " << app->device() << " - " << app->mobile_app_id());
+      policy_manager_->SendNotificationOnPermissionsUpdated(app->mobile_app_id());
+    }
+  }
 }
 
 application_manager::TypeAccess PolicyHandler::ConvertTypeAccess(

--- a/src/components/can_cooperation/reverse_sdl_pt.json
+++ b/src/components/can_cooperation/reverse_sdl_pt.json
@@ -2,7 +2,6 @@
     "policy_table": {
         "module_config": {
             "preloaded_pt": true,
-            "user_consent_passengerRC": true,
             "country_consent_passengersRC": true,
             "exchange_after_x_ignition_cycles": 100,
             "exchange_after_x_kilometers": 1800,
@@ -297,6 +296,16 @@
                 "rpcs": {
                     "Alert": {
                         "hmi_levels": ["BACKGROUND"]
+                    }
+                }
+            },
+            "Notifications-RC": {
+                "rpcs": {
+                    "OnPermissionsChange": {
+                        "hmi_levels": ["BACKGROUND",
+                        "FULL",
+                        "LIMITED",
+                        "NONE"]
                     }
                 }
             },
@@ -2324,7 +2333,7 @@
                 "default_hmi": "NONE",
                 "groups": ["Base-4"],
                 "groups_primaryRC": ["Base-4", "Base-RC", "Radio", "Climate"],
-                "groups_nonPrimaryRC": ["Base-RC", "Radio", "Climate"]
+                "groups_nonPrimaryRC": ["Base-RC", "Radio", "Climate", "Notifications-RC"]
             },
             "8675311": {
                 "keep_context": false,
@@ -2333,7 +2342,7 @@
                 "default_hmi": "NONE",
                 "groups": ["Base-4"],
                 "groups_primaryRC": ["Base-4", "Base-RC", "Radio", "Climate"],
-                "groups_nonPrimaryRC": ["Base-RC", "Radio", "Climate"],
+                "groups_nonPrimaryRC": ["Base-RC", "Radio", "Climate", "Notifications-RC"],
                 "AppHMIType": ["REMOTE_CONTROL"]
             },
             "device": {

--- a/src/components/policy/src/policy/src/access_remote_impl.cc
+++ b/src/components/policy/src/policy/src/access_remote_impl.cc
@@ -47,8 +47,8 @@ namespace policy {
 
 struct IsPrimary {
   bool operator ()(const DeviceData::value_type& item) const {
-    const policy_table::UserConsentRecords& consent =
-        *item.second.user_consent_records;
+    const policy_table::UserConsentRecords& consent = *item.second
+        .user_consent_records;
     policy_table::UserConsentRecords::const_iterator i = consent.find(kPrimary);
     return i != consent.end() && *i->second.is_consented == true;
   }
@@ -160,9 +160,9 @@ void AccessRemoteImpl::Init() {
   policy_table::ModuleConfig& config = cache_->pt_->policy_table.module_config;
   country_consent_ = !config.country_consent_passengersRC.is_initialized()
       || *config.country_consent_passengersRC;
-  enabled_ = country_consent_ &&
-      (!config.user_consent_passengerRC.is_initialized()
-      || *config.user_consent_passengerRC);
+  enabled_ = country_consent_
+      && (!config.user_consent_passengerRC.is_initialized()
+          || *config.user_consent_passengerRC);
 
   const DeviceData& devices = *cache_->pt_->policy_table.device_data;
   DeviceData::const_iterator d = std::find_if(devices.begin(), devices.end(),
@@ -357,16 +357,29 @@ bool AccessRemoteImpl::GetPermissionsForApp(const std::string &device_id,
   return true;
 }
 
+std::ostream& operator <<(std::ostream& output,
+                          const FunctionalGroupIDs& types) {
+  for (FunctionalGroupIDs::const_iterator i = types.begin(); i != types.end();
+      ++i) {
+    output << *i << " ";
+  }
+  return output;
+}
+
+extern std::ostream& operator <<(std::ostream& output,
+                                 const policy_table::Strings& groups);
+
 void AccessRemoteImpl::GetGroupsIds(const std::string &device_id,
                                     const std::string &app_id,
                                     FunctionalGroupIDs& groups_ids) {
   const policy_table::Strings& groups = GetGroups(device_id, app_id);
+  LOG4CXX_DEBUG(logger_, "Groups Names: " << groups);
   groups_ids.resize(groups.size());
   std::transform(groups.begin(), groups.end(), groups_ids.begin(),
                  &CacheManager::GenerateHash);
+  LOG4CXX_DEBUG(logger_, "Groups Ids: " << groups_ids);
 }
 
 const policy_table::Strings AccessRemoteImpl::kGroupsEmpty;
-
 }
 // namespace policy

--- a/src/components/policy/src/policy/src/access_remote_impl.cc
+++ b/src/components/policy/src/policy/src/access_remote_impl.cc
@@ -160,9 +160,9 @@ void AccessRemoteImpl::Init() {
   policy_table::ModuleConfig& config = cache_->pt_->policy_table.module_config;
   country_consent_ = !config.country_consent_passengersRC.is_initialized()
       || *config.country_consent_passengersRC;
-  bool enabled = !config.user_consent_passengerRC.is_initialized()
-      || *config.user_consent_passengerRC;
-  set_enabled(enabled);
+  enabled_ = country_consent_ &&
+      (!config.user_consent_passengerRC.is_initialized()
+      || *config.user_consent_passengerRC);
 
   const DeviceData& devices = *cache_->pt_->policy_table.device_data;
   DeviceData::const_iterator d = std::find_if(devices.begin(), devices.end(),

--- a/src/components/policy/src/policy/src/policy_manager_impl.cc
+++ b/src/components/policy/src/policy/src/policy_manager_impl.cc
@@ -341,7 +341,8 @@ void PolicyManagerImpl::SendNotificationOnPermissionsUpdated(
   default_hmi = "NONE";
 
 #ifdef SDL_REMOTE_CONTROL
-  if (access_remote_->IsPrimaryDevice(device_id)) {
+  if (access_remote_->IsPrimaryDevice(device_id)
+      || access_remote_->IsEnabled()) {
     listener()->OnPermissionsUpdated(application_id, notification_data);
   } else {
     listener()->OnPermissionsUpdated(application_id, notification_data,

--- a/src/components/policy/src/policy/src/policy_manager_impl.cc
+++ b/src/components/policy/src/policy/src/policy_manager_impl.cc
@@ -273,6 +273,15 @@ void PolicyManagerImpl::OnAppsSearchCompleted() {
   }
 }
 
+std::ostream& operator <<(std::ostream& output,
+                          const policy_table::Strings& groups) {
+  for (policy_table::Strings::const_iterator i = groups.begin();
+      i != groups.end(); ++i) {
+    output << static_cast<std::string>(*i) << " ";
+  }
+  return output;
+}
+
 void PolicyManagerImpl::CheckPermissions(const PTString& app_id,
                                          const PTString& hmi_level,
                                           const PTString& rpc,
@@ -297,6 +306,7 @@ void PolicyManagerImpl::CheckPermissions(const PTString& app_id,
 #else  // SDL_REMOTE_CONTROL
   const policy_table::Strings& groups = cache_->GetGroups(app_id);
 #endif  // SDL_REMOTE_CONTROL
+  LOG4CXX_DEBUG(logger_, "Groups: " << groups);
   cache_->CheckPermissions(groups, hmi_level, rpc, result);
 }
 
@@ -577,8 +587,9 @@ void PolicyManagerImpl::GetPermissionsForApp(
   }
 
   FunctionalIdType group_types;
-#ifdef REMOTE_CONTROL
-  bool ret = remote_control->GetPermissionsForApp(device_id, policy_app_id,
+#ifdef SDL_REMOTE_CONTROL
+  allowed_by_default = false;
+  bool ret = access_remote_->GetPermissionsForApp(device_id, policy_app_id,
                                                   group_types);
 #else
   bool ret = cache_->GetPermissionsForApp(device_id, app_id_to_check,


### PR DESCRIPTION
**Implemented:**
1.2. put all aps of "REMOTE-CONTROL" AppHMIType that are curretnly registered from passenger's device(s) into NONE HMILevel
1.3. return DISALLOWED result code to all and any RPCs except RegisterAppInterface (see 1.4 below) from apps of "REMOTE-CONTROL" AppHMIType from passenger's device(s)
2.2. send OnPermissionsChnaged <with appropriate information about assigned permissions> notification to all registered (in case there are any) aps of "REMOTE-CONTROL" AppHMIType
2.3. start processing aps of "REMOTE-CONTROL" AppHMIType from passenger's device(s) as assigned (per other requirements: that is, register, assign permissions, check access, etc.)
3.1. keep "user_consent_passengerRC" field empty until OnReverseAppsAllowing comes from HMI
3.2. behave as per requirement 2 - allow apps from passenger's device by default.

*Notes:*
1.1, 1.4 and 2.1 were implemented before.
1.5 and 2.4 are implemented implicitly.