### PR TITLE
REVSDL-881: fix on RSDL's side: close client's port.

### DIFF
--- a/src/appMain/life_cycle.cc
+++ b/src/appMain/life_cycle.cc
@@ -392,6 +392,9 @@ void LifeCycle::StopComponents() {
     LOG4CXX_ERROR(logger_, "Components wasn't started");
     return;
   }
+
+  functional_modules::PluginManager::destroy();
+
   hmi_handler_->set_message_observer(NULL);
   connection_handler_->set_connection_handler_observer(NULL);
   protocol_handler_->RemoveProtocolObserver(app_manager_);


### PR DESCRIPTION
Fix issue on RSDL side (CAN simulator side remains not fixed) for issue REVSDL-881: stop Plugin Manager on exiting application.