### PR TITLE
Feature/revsdl 976 check module type

### DIFF
--- a/src/components/application_manager/include/application_manager/core_service.h
+++ b/src/components/application_manager/include/application_manager/core_service.h
@@ -71,27 +71,25 @@ class CoreService : public Service {
   /**
    * Checks access to requested equipment of vehicle
    * @param app_id id of application
-   * @param function_id name of RPC
+   * @param module type
    * @param params parameters list
    * @param seat seat of owner's mobile device
    * @return return allowed if access exist,
    * manual if need to send question to driver otherwise disallowed
    */
   virtual TypeAccess CheckAccess(const ApplicationId& app_id,
-                                 const PluginFunctionID& function_id,
+                                 const std::string& module,
                                  const std::vector<std::string>& params,
                                  const SeatLocation& zone);
 
   /**
    * Sets access to functional group which contains given RPC for application
    * @param app_id id of application
-   * @param group_id id RPC
-   * @param zone requested zone
+   * @param module type
    * @param allowed true if driver has given access
    */
   virtual void SetAccess(const ApplicationId& app_id,
-                         const std::string& group_id,
-                         const SeatLocation& zone,
+                         const std::string& module,
                          bool allowed);
 
   /**
@@ -103,18 +101,17 @@ class CoreService : public Service {
 
   /**
    * Resets access by group name for all applications
-   * @param group_name group name
-   * @param zone zone control
+   * @param module type
    */
-  virtual void ResetAccess(const std::string& group_name,
-                           const SeatLocation& zone);
+  virtual void ResetAccessByModule(const std::string& module);
 
   /**
    * Sets device as primary device
    * @param dev_id ID device
    * @param input
    */
-  virtual void SetPrimaryDevice(const uint32_t dev_id, const std::string& input);
+  virtual void SetPrimaryDevice(const uint32_t dev_id,
+                                const std::string& input);
 
   /**
    * Sets mode of remote control (on/off)

--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -99,25 +99,23 @@ class PolicyHandler :
   /**
    * Checks access to equipment of vehicle for application by RPC
    * @param app_id policy id application
-   * @param rpc name of RPC
+   * @param module type
    * @param params parameters list
-   * @param seat current seat of passenger
    * @param zone requested zone control
    */
   application_manager::TypeAccess CheckAccess(const PTString& app_id,
-                                              const PTString& rpc,
+                                              const PTString& module,
                                               const RemoteControlParams& params,
                                               const SeatLocation& zone);
 
   /**
    * Sets access to equipment of vehicle for application by RPC
    * @param app_id policy id application
-   * @param group_name RPC group name
-   * @param zone zone control
+   * @param module type
    * @param allowed true if access is allowed
    */
-  void SetAccess(const PTString& app_id, const PTString& group_name,
-                 const SeatLocation& zone, bool allowed);
+  void SetAccess(const PTString& app_id, const PTString& module,
+                 bool allowed);
 
   /**
    * Resets access application to all resources
@@ -127,10 +125,9 @@ class PolicyHandler :
 
   /**
    * Resets access by group name for all applications
-   * @param group_name group name
-   * @param zone zone control
+   * @param module type
    */
-  void ResetAccess(const std::string& group_name, const SeatLocation& zone);
+  void ResetAccessByModule(const std::string& module);
 
   /**
    * Sets device as primary device

--- a/src/components/application_manager/include/application_manager/service.h
+++ b/src/components/application_manager/include/application_manager/service.h
@@ -70,27 +70,25 @@ class Service {
   /**
    * Checks access to requested equipment of vehicle
    * @param app_id id of application
-   * @param function_id name of RPC
+   * @param module type
    * @param params parameters list
    * @param seat seat of owner's mobile device
    * @return return allowed if access exist,
    * manual if need to send question to driver otherwise disallowed
    */
   virtual TypeAccess CheckAccess(const ApplicationId& app_id,
-                                 const PluginFunctionID& function_id,
+                                 const std::string& module,
                                  const std::vector<std::string>& params,
                                  const SeatLocation& zone) = 0;
 
   /**
    * Sets access to functional group which contains given RPC for application
    * @param app_id id of application
-   * @param group_id id RPC
-   * @param zone requested zone
+   * @param module type
    * @param allowed true if driver has given access
    */
   virtual void SetAccess(const ApplicationId& app_id,
-                         const std::string& group_id,
-                         const SeatLocation& zone,
+                         const std::string& module,
                          bool allowed) = 0;
 
   /**
@@ -101,11 +99,9 @@ class Service {
 
   /**
    * Resets access by group name for all applications
-   * @param group_name group name
-   * @param zone zone control
+   * @param module type
    */
-  virtual void ResetAccess(const std::string& group_name,
-                           const SeatLocation& zone) = 0;
+  virtual void ResetAccessByModule(const std::string& module) = 0;
 
   /**
    * Sets device as primary device

--- a/src/components/application_manager/src/core_service.cc
+++ b/src/components/application_manager/src/core_service.cc
@@ -83,7 +83,7 @@ mobile_apis::Result::eType CoreService::CheckPolicyPermissions(MessagePtr msg) {
 }
 
 TypeAccess CoreService::CheckAccess(const ApplicationId& app_id,
-                                    const PluginFunctionID& function_id,
+                                    const std::string& module,
                                     const std::vector<std::string>& params,
                                     const SeatLocation& zone) {
 #ifdef SDL_REMOTE_CONTROL
@@ -91,21 +91,20 @@ TypeAccess CoreService::CheckAccess(const ApplicationId& app_id,
   if (app) {
 
     return policy::PolicyHandler::instance()->CheckAccess(
-        app->mobile_app_id(), function_id, params, zone);
+        app->mobile_app_id(), module, params, zone);
   }
 #endif  // SDL_REMOTE_CONTROL
   return kNone;
 }
 
 void CoreService::SetAccess(const ApplicationId& app_id,
-                            const std::string& group_name,
-                            const SeatLocation& zone,
+                            const std::string& module,
                             bool allowed) {
 #ifdef SDL_REMOTE_CONTROL
   ApplicationSharedPtr app = GetApplication(app_id);
   if (app) {
     policy::PolicyHandler::instance()->SetAccess(
-        app->mobile_app_id(), group_name, zone, allowed);
+        app->mobile_app_id(), module, allowed);
   }
 #endif  // SDL_REMOTE_CONTROL
 }
@@ -119,10 +118,9 @@ void CoreService::ResetAccess(const ApplicationId& app_id) {
 #endif  // SDL_REMOTE_CONTROL
 }
 
-void CoreService::ResetAccess(const std::string& group_name,
-                              const SeatLocation& zone) {
+void CoreService::ResetAccessByModule(const std::string& module) {
 #ifdef SDL_REMOTE_CONTROL
-  policy::PolicyHandler::instance()->ResetAccess(group_name, zone);
+  policy::PolicyHandler::instance()->ResetAccessByModule(module);
 #endif  // SDL_REMOTE_CONTROL
 }
 

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -1299,20 +1299,19 @@ void PolicyHandler::Add(const std::string& app_id,
 
 #ifdef SDL_REMOTE_CONTROL
 application_manager::TypeAccess PolicyHandler::CheckAccess(
-    const PTString& app_id, const PTString& rpc,
+    const PTString& app_id, const PTString& module,
     const RemoteControlParams& params, const SeatLocation& zone) {
   POLICY_LIB_CHECK(application_manager::TypeAccess::kNone);
-  policy::TypeAccess access = policy_manager_->CheckAccess(app_id, rpc, params,
-                                                           zone);
+  policy::TypeAccess access = policy_manager_->CheckAccess(app_id, module,
+                                                           params, zone);
   return ConvertTypeAccess(access);
 }
 
 void PolicyHandler::SetAccess(const PTString& app_id,
-                              const PTString& group_name,
-                              const SeatLocation& zone,
+                              const PTString& module,
                               bool allowed) {
   POLICY_LIB_CHECK_VOID();
-  policy_manager_->SetAccess(app_id, group_name, zone, allowed);
+  policy_manager_->SetAccess(app_id, module, allowed);
 }
 
 void PolicyHandler::ResetAccess(const PTString& app_id) {
@@ -1320,10 +1319,9 @@ void PolicyHandler::ResetAccess(const PTString& app_id) {
   policy_manager_->ResetAccess(app_id);
 }
 
-void PolicyHandler::ResetAccess(const std::string& group_name,
-                                const SeatLocation& zone) {
+void PolicyHandler::ResetAccessByModule(const std::string& module) {
   POLICY_LIB_CHECK_VOID();
-  policy_manager_->ResetAccess(group_name, zone);
+  policy_manager_->ResetAccessByModule(module);
 }
 
 void PolicyHandler::SetPrimaryDevice(const PTString& dev_id,

--- a/src/components/can_cooperation/reverse_sdl_pt.json
+++ b/src/components/can_cooperation/reverse_sdl_pt.json
@@ -988,31 +988,6 @@
                         "hmi_levels": ["BACKGROUND",
                         "FULL",
                         "LIMITED"]
-                    },
-                    "ButtonPress": {
-                        "hmi_levels": ["BACKGROUND",
-                        "FULL",
-                        "LIMITED"]
-                    },
-                    "GetInteriorVehicleDataCapabilities": {
-                        "hmi_levels": ["BACKGROUND",
-                        "FULL",
-                        "LIMITED"]
-                    },
-                    "GetInteriorVehicleData": {
-                        "hmi_levels": ["BACKGROUND",
-                        "FULL",
-                        "LIMITED"]
-                    },
-                    "SetInteriorVehicleData": {
-                        "hmi_levels": ["BACKGROUND",
-                        "FULL",
-                        "LIMITED"]
-                    },
-                    "OnInteriorVehicleData": {
-                        "hmi_levels": ["BACKGROUND",
-                        "FULL",
-                        "LIMITED"]
                     }
                 }
             },

--- a/src/components/can_cooperation/src/command/base_command_request.cc
+++ b/src/components/can_cooperation/src/command/base_command_request.cc
@@ -313,11 +313,12 @@ bool BaseCommandRequest::CheckPolicy() {
   }
 
   CANAppExtensionPtr extension = GetAppExtension(app_);
-  // TODO(KKolodiy): get zone and params from message
+  // TODO(KKolodiy): get module type, zone and params from message
   SeatLocation zone = 10;
   std::vector<std::string> params;
+  std::string module = "RADIO";
   application_manager::TypeAccess access = service_->CheckAccess(
-      app_->app_id(), message_->function_name(), params, zone);
+      app_->app_id(), module, params, zone);
 
   switch (access) {
     case application_manager::kAllowed:
@@ -375,10 +376,9 @@ void BaseCommandRequest::ProcessAccessResponse(
   } else {
     SendResponse(false, result_codes::kDisallowed, "");
   }
-  // TODO(KKolodiy): get group name and zone from message
-  std::string group_name = "Radio";
-  SeatLocation zone = 10;
-  service_->SetAccess(app_->app_id(), group_name, zone, allowed);
+  // TODO(KKolodiy): get module from message
+  std::string module = "RADIO";
+  service_->SetAccess(app_->app_id(), module, allowed);
 }
 
 }  // namespace commands

--- a/src/components/can_cooperation/test/include/mock_service.h
+++ b/src/components/can_cooperation/test/include/mock_service.h
@@ -58,16 +58,14 @@ class MockService : public Service {
           const PluginFunctionID& function_id,
           const std::vector<std::string>& params,
           const SeatLocation& zone));
-  MOCK_METHOD4(SetAccess,
+  MOCK_METHOD3(SetAccess,
       void(const ApplicationId& app_id,
-          const std::string& group_id,
-          const SeatLocation& zone,
+          const std::string& module,
           bool allowed));
   MOCK_METHOD1(ResetAccess, void(const ApplicationId& app_id));
+  MOCK_METHOD1(ResetAccessByModule, void(const std::string& module));
   MOCK_METHOD2(SetPrimaryDevice, void(const uint32_t dev_id,
                                       const std::string& input));
-  MOCK_METHOD2(ResetAccess, void(const std::string& group_name,
-          const SeatLocation& zone));
   MOCK_METHOD1(SetRemoteControl, void(bool enabled));
 };
 

--- a/src/components/functional_module/test/include/mock_service.h
+++ b/src/components/functional_module/test/include/mock_service.h
@@ -58,14 +58,12 @@ class MockService : public Service {
           const PluginFunctionID& function_id,
           const std::vector<std::string>& params,
           const SeatLocation& zone));
-  MOCK_METHOD4(SetAccess,
+  MOCK_METHOD3(SetAccess,
       void(const ApplicationId& app_id,
-           const std::string& group_id,
-           const SeatLocation& zone,
+           const std::string& module,
            bool allowed));
   MOCK_METHOD1(ResetAccess, void(const ApplicationId& app_id));
-  MOCK_METHOD2(ResetAccess, void(const std::string& group_name,
-                                 const SeatLocation& zone));
+  MOCK_METHOD1(ResetAccessByModule, void(const std::string& module));
   MOCK_METHOD2(SetPrimaryDevice, void(const uint32_t dev_id,
                                       const std::string& input));
   MOCK_METHOD1(SetRemoteControl, void(bool enabled));

--- a/src/components/policy/src/policy/include/policy/access_remote.h
+++ b/src/components/policy/src/policy/include/policy/access_remote.h
@@ -178,16 +178,6 @@ class AccessRemote {
   virtual bool CheckParameters(/* module, zone, params */) const = 0;
 
   /**
-   * Find group by RPC name and list of parameters
-   * @param who subject is dev_id and app_id
-   * @param rpc name of RPC
-   * @param params parameters list
-   * @return name of group
-   */
-  virtual PTString FindGroup(const Subject& who, const PTString& rpc,
-                             const RemoteControlParams& params) const = 0;
-
-  /**
    * Sets HMI types if application has default policy permissions
    * @param app_id ID application
    * @param hmi_types list of HMI types

--- a/src/components/policy/src/policy/include/policy/access_remote.h
+++ b/src/components/policy/src/policy/include/policy/access_remote.h
@@ -65,17 +65,16 @@ inline std::ostream& operator<<(std::ostream& output, const Subject& who) {
 }
 
 struct Object {
-  PTString group_id;
-  SeatLocation zone;
+  policy_table::ModuleType module;
 };
 inline bool operator<(const Object& x, const Object& y) {
-  return x.group_id < y.group_id || x.zone < y.zone;
+  return x < y;
 }
 inline bool operator==(const Object& x, const Object& y) {
-  return x.group_id == y.group_id && x.zone == y.zone;
+  return x == y;
 }
 inline std::ostream& operator<<(std::ostream& output, const Object& what) {
-  output << "Object(group:" << what.group_id << ", zone:" << what.zone << ")";
+  output << "Object(module:" << what.module << ")";
   return output;
 }
 
@@ -162,6 +161,21 @@ class AccessRemote {
    * manual if need to ask driver
    */
   virtual TypeAccess Check(const Subject& who, const Object& what) const = 0;
+
+  /**
+   *
+   * @param app_id
+   * @param module
+   * @return
+   */
+  virtual bool CheckModuleType(const PTString& app_id,
+                               policy_table::ModuleType module) const = 0;
+
+  /**
+   *
+   * @return
+   */
+  virtual bool CheckParameters(/* module, zone, params */) const = 0;
 
   /**
    * Find group by RPC name and list of parameters

--- a/src/components/policy/src/policy/include/policy/access_remote.h
+++ b/src/components/policy/src/policy/include/policy/access_remote.h
@@ -68,10 +68,10 @@ struct Object {
   policy_table::ModuleType module;
 };
 inline bool operator<(const Object& x, const Object& y) {
-  return x < y;
+  return x.module < y.module;
 }
 inline bool operator==(const Object& x, const Object& y) {
-  return x == y;
+  return x.module == y.module;
 }
 inline std::ostream& operator<<(std::ostream& output, const Object& what) {
   output << "Object(module:" << EnumToJsonString(what.module) << ")";

--- a/src/components/policy/src/policy/include/policy/access_remote.h
+++ b/src/components/policy/src/policy/include/policy/access_remote.h
@@ -74,7 +74,7 @@ inline bool operator==(const Object& x, const Object& y) {
   return x == y;
 }
 inline std::ostream& operator<<(std::ostream& output, const Object& what) {
-  output << "Object(module:" << what.module << ")";
+  output << "Object(module:" << EnumToJsonString(what.module) << ")";
   return output;
 }
 
@@ -163,17 +163,17 @@ class AccessRemote {
   virtual TypeAccess Check(const Subject& who, const Object& what) const = 0;
 
   /**
-   *
-   * @param app_id
-   * @param module
-   * @return
+   * Checks permissions for module
+   * @param app_id application ID
+   * @param module type
+   * @return true if allowed
    */
   virtual bool CheckModuleType(const PTString& app_id,
                                policy_table::ModuleType module) const = 0;
 
   /**
-   *
-   * @return
+   * Checks permissions for parameters
+   * @return true if allowed
    */
   virtual bool CheckParameters(/* module, zone, params */) const = 0;
 

--- a/src/components/policy/src/policy/include/policy/access_remote_impl.h
+++ b/src/components/policy/src/policy/include/policy/access_remote_impl.h
@@ -66,13 +66,16 @@ class AccessRemoteImpl : public AccessRemote {
 
   virtual bool IsPrimaryDevice(const PTString& dev_id) const;
   virtual void SetPrimaryDevice(const PTString& dev_id, const PTString& input);
-  virtual PTString PrimaryDevice() const;  
+  virtual PTString PrimaryDevice() const;
 
   virtual void Allow(const Subject& who, const Object& what);
   virtual void Deny(const Subject& who, const Object& what);
   virtual void Reset(const Subject& who);
   virtual void Reset(const Object& what);
   virtual TypeAccess Check(const Subject& who, const Object& what) const;
+  virtual bool CheckModuleType(const PTString& app_id,
+                               policy_table::ModuleType module) const;
+  virtual bool CheckParameters(/* module, zone, params */) const;
   virtual PTString FindGroup(const Subject& who, const PTString& rpc,
                              const RemoteControlParams& params) const;
   virtual void SetDefaultHmiTypes(const std::string& app_id,

--- a/src/components/policy/src/policy/include/policy/access_remote_impl.h
+++ b/src/components/policy/src/policy/include/policy/access_remote_impl.h
@@ -101,7 +101,11 @@ class AccessRemoteImpl : public AccessRemote {
   FRIEND_TEST(AccessRemoteImplTest, CheckAllowed);
   FRIEND_TEST(AccessRemoteImplTest, CheckDisallowed);
   FRIEND_TEST(AccessRemoteImplTest, CheckManual);
+  FRIEND_TEST(AccessRemoteImplTest, CheckModuleType);
   FRIEND_TEST(AccessRemoteImplTest, SetPrimaryDevice);
+  FRIEND_TEST(AccessRemoteImplTest, EnableDisable);
+  FRIEND_TEST(AccessRemoteImplTest, SetDefaultHmiTypes);
+  FRIEND_TEST(AccessRemoteImplTest, GetGroups);
 };
 
 }  // namespace policy

--- a/src/components/policy/src/policy/include/policy/access_remote_impl.h
+++ b/src/components/policy/src/policy/include/policy/access_remote_impl.h
@@ -43,17 +43,6 @@ using policy_table::FunctionalGroupings;
 
 namespace policy {
 
-struct Match {
- private:
-  const FunctionalGroupings& groups_;
-  const PTString& rpc_;
-  const RemoteControlParams& params_;
- public:
-  Match(const FunctionalGroupings& groups, const PTString& rpc,
-        const RemoteControlParams& params);
-  bool operator ()(const PTString& item) const;
-};
-
 class AccessRemoteImpl : public AccessRemote {
  public:
   AccessRemoteImpl();
@@ -76,8 +65,6 @@ class AccessRemoteImpl : public AccessRemote {
   virtual bool CheckModuleType(const PTString& app_id,
                                policy_table::ModuleType module) const;
   virtual bool CheckParameters(/* module, zone, params */) const;
-  virtual PTString FindGroup(const Subject& who, const PTString& rpc,
-                             const RemoteControlParams& params) const;
   virtual void SetDefaultHmiTypes(const std::string& app_id,
                                   const std::vector<int>& hmi_types);
   virtual const policy_table::Strings& GetGroups(const PTString& device_id,

--- a/src/components/policy/src/policy/include/policy/cache_manager.h
+++ b/src/components/policy/src/policy/include/policy/cache_manager.h
@@ -636,6 +636,10 @@ private:
   BackgroundBackuper* backuper_;
 
   friend class AccessRemoteImpl;
+  FRIEND_TEST(AccessRemoteImplTest, CheckModuleType);
+  FRIEND_TEST(AccessRemoteImplTest, SetPrimaryDevice);
+  FRIEND_TEST(AccessRemoteImplTest, EnableDisable);
+  FRIEND_TEST(AccessRemoteImplTest, GetGroups);
 };
 } // policy
 

--- a/src/components/policy/src/policy/include/policy/policy_manager.h
+++ b/src/components/policy/src/policy/include/policy/policy_manager.h
@@ -404,22 +404,23 @@ class PolicyManager : public usage_statistics::StatisticsManager {
     /**
      * Checks access to equipment of vehicle for application by RPC
      * @param app_id policy id application
-     * @param rpc name of RPC
+     * @param module
      * @param params parameters list
+     * @param zone control
      */
-    virtual TypeAccess CheckAccess(const PTString& app_id, const PTString& rpc,
+    virtual TypeAccess CheckAccess(const PTString& app_id,
+                                   const PTString& module,
                                    const RemoteControlParams& params,
                                    const SeatLocation& zone) = 0;
 
     /**
      * Sets access to equipment of vehicle for application by RPC
      * @param app_id policy id application
-     * @param group_name RPC group name
-     * @param zone zone control
+     * @param module type
      * @param allowed true if access is allowed
      */
-    virtual void SetAccess(const PTString& app_id, const PTString& group_name,
-                           const SeatLocation zone, bool allowed) = 0;
+    virtual void SetAccess(const PTString& app_id, const PTString& module,
+                           bool allowed) = 0;
 
     /**
      * Resets access application to all resources
@@ -429,11 +430,9 @@ class PolicyManager : public usage_statistics::StatisticsManager {
 
     /**
      * Resets access by functional group for all applications
-     * @param group_name group name
-     * @param zone zone control
+     * @param module type
      */
-    virtual void ResetAccess(const PTString& group_name,
-                             const SeatLocation zone) = 0;
+    virtual void ResetAccessByModule(const PTString& module) = 0;
 
     /**
      * Sets driver as primary device

--- a/src/components/policy/src/policy/include/policy/policy_manager_impl.h
+++ b/src/components/policy/src/policy/include/policy/policy_manager_impl.h
@@ -169,16 +169,16 @@ class PolicyManagerImpl : public PolicyManager {
     virtual void OnAppsSearchCompleted();
 
 #ifdef SDL_REMOTE_CONTROL
-    virtual TypeAccess CheckAccess(const PTString& app_id, const PTString& rpc,
+    virtual TypeAccess CheckAccess(const PTString& app_id,
+                                   const PTString& module,
                                    const RemoteControlParams& params,
                                    const SeatLocation& zone);
-    virtual void SetAccess(const PTString& app_id, const PTString& group_name,
-                           const SeatLocation zone, bool allowed);
-    virtual void ResetAccess(const PTString& rpc);
-    virtual void ResetAccess(const PTString& group_name,
-                             const SeatLocation zone);
+    virtual void SetAccess(const PTString& app_id, const PTString& module,
+                           bool allowed);
+    virtual void ResetAccess(const PTString& app_id);
+    virtual void ResetAccessByModule(const PTString& module);
     virtual void SetPrimaryDevice(const PTString& dev_id, const PTString& input);
-    virtual PTString PrimaryDevice() const;    
+    virtual PTString PrimaryDevice() const;
     virtual void SetRemoteControl(bool enabled);
 #endif  // SDL_REMOTE_CONTROL
 

--- a/src/components/policy/src/policy/include/policy/policy_manager_impl.h
+++ b/src/components/policy/src/policy/include/policy/policy_manager_impl.h
@@ -274,12 +274,20 @@ class PolicyManagerImpl : public PolicyManager {
     bool IsPTValid(utils::SharedPtr<policy_table::Table> policy_table,
                    policy_table::PolicyTableType type) const;
 
+
 private:
     PolicyListener* listener_;
 
     UpdateStatusManager update_status_manager_;
     CacheManagerInterfaceSPtr cache_;
 #ifdef SDL_REMOTE_CONTROL
+    bool CheckModulePermissions(const PTString& app_id,
+                                policy_table::ModuleType module,
+                                const RemoteControlParams& params,
+                                const SeatLocation& zone);
+    TypeAccess CheckDriverConsent(const PTString& app_id,
+                                  policy_table::ModuleType module);
+
     utils::SharedPtr<AccessRemote> access_remote_;
 #endif  // SDL_REMOTE_CONTROL
     sync_primitives::Lock apps_registration_lock_;

--- a/src/components/policy/src/policy/src/access_remote_impl.cc
+++ b/src/components/policy/src/policy/src/access_remote_impl.cc
@@ -183,7 +183,23 @@ TypeAccess AccessRemoteImpl::Check(const Subject& who,
 
 bool AccessRemoteImpl::CheckModuleType(const PTString& app_id,
                                        policy_table::ModuleType module) const {
-  return true;
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (!cache_->IsApplicationRepresented(app_id)) {
+    return false;
+  }
+
+  const policy_table::ApplicationParams& app = cache_->pt_->policy_table
+      .app_policies[app_id];
+  if (!app.moduleType.is_initialized()) {
+    return false;
+  }
+
+  const policy_table::ModuleTypes& modules = *app.moduleType;
+  if (modules.empty()) {
+    return true;
+  }
+
+  return std::find(modules.begin(), modules.end(), module) != modules.end();
 }
 
 bool AccessRemoteImpl::CheckParameters(/* module, zone, params */) const {

--- a/src/components/policy/src/policy/src/access_remote_impl.cc
+++ b/src/components/policy/src/policy/src/access_remote_impl.cc
@@ -214,6 +214,15 @@ TypeAccess AccessRemoteImpl::Check(const Subject& who,
   return ret;
 }
 
+bool AccessRemoteImpl::CheckModuleType(const PTString& app_id,
+                                       policy_table::ModuleType module) const {
+  return true;
+}
+
+bool AccessRemoteImpl::CheckParameters(/* module, zone, params */) const {
+  return true;
+}
+
 void AccessRemoteImpl::Allow(const Subject& who, const Object& what) {
   LOG4CXX_AUTO_TRACE(logger_);
   acl_[what][who] = TypeAccess::kAllowed;

--- a/src/components/policy/src/policy/src/access_remote_impl.cc
+++ b/src/components/policy/src/policy/src/access_remote_impl.cc
@@ -100,6 +100,8 @@ struct ToHMIType {
       LOG4CXX_WARN(logger_, "HMI types isn't known " << item);
       type = policy_table::AHT_DEFAULT;
     }
+    LOG4CXX_DEBUG(logger_,
+                  "HMI type: " << item << " - " << EnumToJsonString(type));
     return policy_table::AppHMITypes::value_type(type);
   }
 };
@@ -274,12 +276,6 @@ void AccessRemoteImpl::SetDefaultHmiTypes(const std::string& app_id,
   HMIList::mapped_type types;
   std::transform(hmi_types.begin(), hmi_types.end(), std::back_inserter(types),
                  ToHMIType());
-  std::vector<int>::const_iterator i;
-  HMIList::mapped_type::const_iterator j;
-  for (i = hmi_types.begin(), j = types.begin();
-      i != hmi_types.end(), j != types.end(); ++i, ++j) {
-    LOG4CXX_DEBUG(logger_, "DEFHMI: " << *i << " - " << *j);
-  }
   hmi_types_[app_id] = types;
 }
 

--- a/src/components/policy/src/policy/src/policy_manager_impl.cc
+++ b/src/components/policy/src/policy/src/policy_manager_impl.cc
@@ -952,43 +952,58 @@ void PolicyManagerImpl::set_cache_manager(
 
 #ifdef SDL_REMOTE_CONTROL
 TypeAccess PolicyManagerImpl::CheckAccess(
-    const PTString& app_id, const PTString& rpc,
+    const PTString& app_id, const PTString& module,
     const RemoteControlParams& params, const SeatLocation& zone) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  policy_table::ModuleType module_type;
+  bool is_valid = EnumFromJsonString(module, &module_type);
+  if (is_valid && CheckModulePermissions(app_id, module_type, params, zone)) {
+    return CheckDriverConsent(app_id, module_type);
+  }
+  return TypeAccess::kDisallowed;
+}
+
+bool PolicyManagerImpl::CheckModulePermissions(
+    const PTString& app_id, policy_table::ModuleType module,
+    const RemoteControlParams& params, const SeatLocation& zone) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  return access_remote_->CheckModuleType(app_id, module)
+      && access_remote_->CheckParameters(/* module, zone, params */);
+}
+
+TypeAccess PolicyManagerImpl::CheckDriverConsent(
+    const PTString& app_id, policy_table::ModuleType module) {
+  LOG4CXX_AUTO_TRACE(logger_);
   TypeAccess access = TypeAccess::kDisallowed;
-
   std::string dev_id = GetCurrentDeviceId(app_id);
+  Subject who = {dev_id, app_id};
+  Object what = {module};
   if (access_remote_->IsPrimaryDevice(dev_id)) {
-
-    Subject who = {dev_id, app_id};
-    PTString group_name = access_remote_->FindGroup(who, rpc, params);
-    Object what = {group_name, zone};
     access = access_remote_->Check(who, what);
     if (access == TypeAccess::kManual) {
       access_remote_->Allow(who, what);
       access = TypeAccess::kAllowed;
     }
   } else if (access_remote_->IsEnabled()) {
-    Subject who = {dev_id, app_id};
-    PTString group_name = access_remote_->FindGroup(who, rpc, params);
-    if (group_name.empty()) {
-      // Group wasn't found => request is disallowed
-      access = TypeAccess::kDisallowed;
-    } else {
-      Object what = {group_name, zone};
-      access = access_remote_->Check(who, what);
-    }
+    access = access_remote_->Check(who, what);
   }
   return access;
 }
 
 void PolicyManagerImpl::SetAccess(const PTString& app_id,
-                                  const PTString& group_name,
+                                  const PTString& module,
                                   const SeatLocation zone,
                                   bool allowed) {
   LOG4CXX_AUTO_TRACE(logger_);
+  policy_table::ModuleType module_type;
+  bool is_valid = EnumFromJsonString(module, &module_type);
+  if (!is_valid) {
+    return;
+  }
+
   std::string dev_id = GetCurrentDeviceId(app_id);
   Subject who = {dev_id, app_id};
-  Object what = {group_name, zone};
+  Object what = {module_type};
   if (allowed) {
     access_remote_->Allow(who, what);
   } else {
@@ -1003,11 +1018,17 @@ void PolicyManagerImpl::ResetAccess(const PTString& app_id) {
   access_remote_->Reset(who);
 }
 
-void PolicyManagerImpl::ResetAccess(const PTString& group_name,
+void PolicyManagerImpl::ResetAccess(const PTString& module,
                                     const SeatLocation zone) {
   LOG4CXX_AUTO_TRACE(logger_);
-  Object who = {group_name, zone};
-  access_remote_->Reset(who);
+  policy_table::ModuleType module_type;
+  bool is_valid = EnumFromJsonString(module, &module_type);
+  if (!is_valid) {
+    return;
+  }
+
+  Object what = {module_type};
+  access_remote_->Reset(what);
 }
 
 void PolicyManagerImpl::SetPrimaryDevice(const PTString& dev_id,

--- a/src/components/policy/src/policy/src/policy_manager_impl.cc
+++ b/src/components/policy/src/policy/src/policy_manager_impl.cc
@@ -992,7 +992,6 @@ TypeAccess PolicyManagerImpl::CheckDriverConsent(
 
 void PolicyManagerImpl::SetAccess(const PTString& app_id,
                                   const PTString& module,
-                                  const SeatLocation zone,
                                   bool allowed) {
   LOG4CXX_AUTO_TRACE(logger_);
   policy_table::ModuleType module_type;
@@ -1018,8 +1017,7 @@ void PolicyManagerImpl::ResetAccess(const PTString& app_id) {
   access_remote_->Reset(who);
 }
 
-void PolicyManagerImpl::ResetAccess(const PTString& module,
-                                    const SeatLocation zone) {
+void PolicyManagerImpl::ResetAccessByModule(const PTString& module) {
   LOG4CXX_AUTO_TRACE(logger_);
   policy_table::ModuleType module_type;
   bool is_valid = EnumFromJsonString(module, &module_type);

--- a/src/components/policy/test/access_remote_impl_test.cc
+++ b/src/components/policy/test/access_remote_impl_test.cc
@@ -38,7 +38,7 @@ namespace policy {
 TEST(AccessRemoteImplTest, Allow) {
   AccessRemoteImpl access_remote;
   Subject who = { "dev1", "12345" };
-  Object what = { "group1", 1 };
+  Object what = { policy_table::MT_RADIO };
   access_remote.Allow(who, what);
   AccessRemoteImpl::AccessControlList::const_iterator i = access_remote.acl_
       .find(what);
@@ -52,21 +52,17 @@ TEST(AccessRemoteImplTest, KeyMapTest) {
   // Testing operator < to use as key of map
   AccessRemoteImpl access_remote;
   Subject who = { "dev1", "12345" };
-  Object what1 = { "1", 1 };
-  Object what2 = { "1", 2 };
-  Object what3 = { "2", 1 };
-  Object what4 = { "2", 2 };
+  Object what1 = { policy_table::MT_RADIO };
+  Object what2 = { policy_table::MT_CLIMATE };
   access_remote.Allow(who, what1);
   access_remote.Allow(who, what2);
-  access_remote.Allow(who, what3);
-  access_remote.Allow(who, what4);
-  ASSERT_EQ(4, access_remote.acl_.size());
+  ASSERT_EQ(2, access_remote.acl_.size());
 }
 
 TEST(AccessRemoteImplTest, Deny) {
   AccessRemoteImpl access_remote;
   Subject who = { "dev1", "12345" };
-  Object what = { "group1", 1 };
+  Object what = { policy_table::MT_RADIO };
   access_remote.Deny(who, what);
   AccessRemoteImpl::AccessControlList::const_iterator i = access_remote.acl_
       .find(what);
@@ -79,7 +75,7 @@ TEST(AccessRemoteImplTest, Deny) {
 TEST(AccessRemoteImplTest, ChangeAccess) {
   AccessRemoteImpl access_remote;
   Subject who = { "dev1", "12345" };
-  Object what = { "group1", 1 };
+  Object what = { policy_table::MT_RADIO };
   access_remote.Allow(who, what);
   ASSERT_EQ(TypeAccess::kAllowed, access_remote.acl_[what][who]);
   access_remote.Deny(who, what);
@@ -91,8 +87,8 @@ TEST(AccessRemoteImplTest, ChangeAccess) {
 TEST(AccessRemoteImplTest, ResetBySubject) {
   AccessRemoteImpl access_remote;
   Subject who = { "dev1", "12345" };
-  Object what1 = { "group1", 1 };
-  Object what2 = { "group2", 2 };
+  Object what1 = { policy_table::MT_RADIO };
+  Object what2 = { policy_table::MT_CLIMATE };
   access_remote.Allow(who, what1);
   access_remote.Deny(who, what2);
   ASSERT_EQ(2, access_remote.acl_.size());
@@ -109,7 +105,7 @@ TEST(AccessRemoteImplTest, ResetByObject) {
   AccessRemoteImpl access_remote;
   Subject who1 = { "dev1", "12345" };
   Subject who2 = { "dev2", "123456" };
-  Object what = { "group1", 1 };
+  Object what = { policy_table::MT_RADIO };
   access_remote.Allow(who1, what);
   access_remote.Deny(who2, what);
   ASSERT_EQ(1, access_remote.acl_.size());
@@ -122,7 +118,7 @@ TEST(AccessRemoteImplTest, ResetByObject) {
 TEST(AccessRemoteImplTest, CheckAllowed) {
   AccessRemoteImpl access_remote;
   Subject who = { "dev1", "12345" };
-  Object what = { "group1", 1 };
+  Object what = { policy_table::MT_RADIO };
   access_remote.Allow(who, what);
 
   EXPECT_EQ(TypeAccess::kAllowed, access_remote.Check(who, what));
@@ -132,7 +128,7 @@ TEST(AccessRemoteImplTest, CheckDisallowed) {
   AccessRemoteImpl access_remote;
   Subject who = { "dev1", "12345" };
   Subject who1 = { "dev1", "123456" };
-  Object what = { "group1", 1 };
+  Object what = { policy_table::MT_RADIO };
 
   access_remote.Allow(who, what);
   EXPECT_EQ(TypeAccess::kDisallowed, access_remote.Check(who1, what));
@@ -146,7 +142,7 @@ TEST(AccessRemoteImplTest, CheckManual) {
   AccessRemoteImpl access_remote;
   Subject who = { "dev1", "12345" };
   Subject who1 = { "dev1", "123456" };
-  Object what = { "group1", 1 };
+  Object what = { policy_table::MT_RADIO };
 
   EXPECT_EQ(TypeAccess::kManual, access_remote.Check(who, what));
 

--- a/src/components/policy/test/access_remote_impl_test.cc
+++ b/src/components/policy/test/access_remote_impl_test.cc
@@ -150,27 +150,5 @@ TEST(AccessRemoteImplTest, CheckManual) {
   EXPECT_EQ(TypeAccess::kManual, access_remote.Check(who, what));
 }
 
-TEST(AccessRemoteImplTest, MatchPredicate) {
-  policy_table::FunctionalGroupings groups;
-  policy_table::Rpc& rpcs = groups["group1"].rpcs;
-  policy_table::RpcParameters& rpc = rpcs["SetMaxVolume"];
-  rpc.parameters->push_back(policy_table::P_VIN);
-
-  RemoteControlParams empty;
-  RemoteControlParams vin;
-  vin.push_back("vin");
-  RemoteControlParams gps;
-  gps.push_back("gps");
-  RemoteControlParams wrong;
-  wrong.push_back("wrong");
-
-  EXPECT_TRUE(Match(groups, "SetMaxVolume", vin)("group1"));
-  EXPECT_FALSE(Match(groups, "Any", empty)("no-group"));
-  EXPECT_FALSE(Match(groups, "no-rpc", empty)("group1"));
-  EXPECT_FALSE(Match(groups, "SetMaxVolume", empty)("group1"));
-  EXPECT_FALSE(Match(groups, "SetMaxVolume", wrong)("group1"));
-  EXPECT_FALSE(Match(groups, "SetMaxVolume", gps)("group1"));
-}
-
 }  // namespace policy
 

--- a/src/components/policy/test/access_remote_impl_test.cc
+++ b/src/components/policy/test/access_remote_impl_test.cc
@@ -150,5 +150,157 @@ TEST(AccessRemoteImplTest, CheckManual) {
   EXPECT_EQ(TypeAccess::kManual, access_remote.Check(who, what));
 }
 
+TEST(AccessRemoteImplTest, CheckModuleType) {
+  AccessRemoteImpl access_remote;
+  access_remote.cache_->pt_ = new policy_table::Table();
+
+  // No application
+  EXPECT_FALSE(access_remote.CheckModuleType("1234", policy_table::MT_RADIO));
+
+  // No modules
+  policy_table::ApplicationPolicies& apps = access_remote.cache_->pt_
+      ->policy_table.app_policies;
+  apps["1234"];
+  EXPECT_FALSE(access_remote.CheckModuleType("1234", policy_table::MT_RADIO));
+
+  // Empty modules
+  policy_table::ModuleTypes& modules = *apps["1234"].moduleType;
+  modules.mark_initialized();
+  EXPECT_TRUE(access_remote.CheckModuleType("1234", policy_table::MT_RADIO));
+  EXPECT_TRUE(access_remote.CheckModuleType("1234", policy_table::MT_CLIMATE));
+
+  // Specific modules
+  modules.push_back(policy_table::MT_RADIO);
+  EXPECT_TRUE(access_remote.CheckModuleType("1234", policy_table::MT_RADIO));
+  EXPECT_FALSE(access_remote.CheckModuleType("1234", policy_table::MT_CLIMATE));
+}
+
+TEST(AccessRemoteImplTest, SetPrimaryDevice) {
+  AccessRemoteImpl access_remote;
+  access_remote.cache_->pt_ = new policy_table::Table();
+
+  // One device
+  access_remote.SetPrimaryDevice("dev1", "GUI");
+  policy_table::DeviceData& devices = *access_remote.cache_->pt_->policy_table
+      .device_data;
+  policy_table::ConsentRecords& record =
+      (*devices["dev1"].user_consent_records)[kPrimary];
+  EXPECT_TRUE(*record.is_consented);
+  EXPECT_EQ("dev1", access_remote.PrimaryDevice());
+
+  // Few devices
+  access_remote.SetPrimaryDevice("dev2", "GUI");
+  access_remote.SetPrimaryDevice("dev3", "GUI");
+  access_remote.SetPrimaryDevice("dev4", "GUI");
+  access_remote.SetPrimaryDevice("dev1", "GUI");
+  policy_table::ConsentRecords& record1 =
+      (*devices["dev1"].user_consent_records)[kPrimary];
+  EXPECT_TRUE(*record1.is_consented);
+  policy_table::ConsentRecords& record2 =
+      (*devices["dev2"].user_consent_records)[kPrimary];
+  EXPECT_FALSE(*record2.is_consented);
+  policy_table::ConsentRecords& record3 =
+      (*devices["dev3"].user_consent_records)[kPrimary];
+  EXPECT_FALSE(*record3.is_consented);
+  policy_table::ConsentRecords& record4 =
+      (*devices["dev4"].user_consent_records)[kPrimary];
+  EXPECT_FALSE(*record4.is_consented);
+  EXPECT_EQ("dev1", access_remote.PrimaryDevice());
+}
+
+TEST(AccessRemoteImplTest, EnableDisable) {
+  AccessRemoteImpl access_remote;
+  access_remote.cache_->pt_ = new policy_table::Table();
+  policy_table::ModuleConfig& config = access_remote.cache_->pt_->policy_table
+      .module_config;
+
+  // Country is enabled
+  access_remote.enabled_ = true;
+  access_remote.country_consent_ = true;
+  *config.country_consent_passengersRC = true;
+  access_remote.Enable();
+  EXPECT_TRUE(*config.user_consent_passengerRC);
+  EXPECT_TRUE(*config.country_consent_passengersRC);
+  EXPECT_TRUE(access_remote.country_consent_);
+  EXPECT_TRUE(access_remote.IsEnabled());
+
+  access_remote.Disable();
+  EXPECT_FALSE(*config.user_consent_passengerRC);
+  EXPECT_TRUE(*config.country_consent_passengersRC);
+  EXPECT_TRUE(access_remote.country_consent_);
+  EXPECT_FALSE(access_remote.IsEnabled());
+
+  // Country is disabled
+  access_remote.enabled_ = false;
+  access_remote.country_consent_ = false;
+  *config.country_consent_passengersRC = false;
+  access_remote.Enable();
+  EXPECT_TRUE(*config.user_consent_passengerRC);
+  EXPECT_FALSE(*config.country_consent_passengersRC);
+  EXPECT_FALSE(access_remote.country_consent_);
+  EXPECT_FALSE(access_remote.IsEnabled());
+
+  access_remote.Disable();
+  EXPECT_FALSE(*config.user_consent_passengerRC);
+  EXPECT_FALSE(*config.country_consent_passengersRC);
+  EXPECT_FALSE(access_remote.country_consent_);
+  EXPECT_FALSE(access_remote.IsEnabled());
+}
+
+TEST(AccessRemoteImplTest, SetDefaultHmiTypes) {
+  AccessRemoteImpl access_remote;
+
+  std::vector<int> hmi_expected;
+  hmi_expected.push_back(2);
+  hmi_expected.push_back(6);
+  access_remote.SetDefaultHmiTypes("1234", hmi_expected);
+
+  EXPECT_NE(access_remote.hmi_types_.end(),
+            access_remote.hmi_types_.find("1234"));
+  policy_table::AppHMITypes& hmi_output = access_remote.hmi_types_["1234"];
+  EXPECT_EQ(2, hmi_output.size());
+  EXPECT_EQ(policy_table::AHT_MEDIA, hmi_output[0]);
+  EXPECT_EQ(policy_table::AHT_SOCIAL, hmi_output[1]);
+}
+
+TEST(AccessRemoteImplTest, GetGroups) {
+  AccessRemoteImpl access_remote;
+  access_remote.primary_device_ = "dev1";
+  access_remote.enabled_ = true;
+  access_remote.hmi_types_["1234"].push_back(policy_table::AHT_REMOTE_CONTROL);
+
+  access_remote.cache_->pt_ = new policy_table::Table();
+  policy_table::ApplicationPolicies& apps = access_remote.cache_->pt_
+      ->policy_table.app_policies;
+  apps["1234"].groups.push_back("group_default");
+  apps["1234"].groups_nonPrimaryRC->push_back("group_non_primary");
+  apps["1234"].groups_primaryRC->push_back("group_primary");
+  apps["1234"].AppHMIType->push_back(policy_table::AHT_MEDIA);
+
+  // Default groups
+  const policy_table::Strings& groups1 = access_remote.GetGroups("dev1",
+                                                                 "1234");
+  EXPECT_EQ(std::string("group_default"), std::string(groups1[0]));
+
+  // Primary groups
+  apps["1234"].set_to_string(policy::kDefaultId);
+  const policy_table::Strings& groups2 = access_remote.GetGroups("dev1",
+                                                                 "1234");
+  EXPECT_EQ(std::string("group_primary"), std::string(groups2[0]));
+
+  // Non primary groups
+  apps["1234"].set_to_string(policy::kDefaultId);
+  const policy_table::Strings& groups3 = access_remote.GetGroups("dev2",
+                                                                 "1234");
+  EXPECT_EQ(std::string("group_non_primary"), std::string(groups3[0]));
+
+  // Empty groups
+  access_remote.enabled_ = false;
+  apps["1234"].set_to_string(policy::kDefaultId);
+  const policy_table::Strings& groups4 = access_remote.GetGroups("dev2",
+                                                                 "1234");
+  EXPECT_TRUE(groups4.empty());
+}
+
 }  // namespace policy
 

--- a/src/components/policy/test/include/mock_access_remote.h
+++ b/src/components/policy/test/include/mock_access_remote.h
@@ -80,6 +80,9 @@ class MockAccessRemote : public AccessRemote {
       const policy_table::Strings&(const PTString& device_id, const PTString& app_id));
   MOCK_METHOD3(GetPermissionsForApp,
       bool (const std::string& device_id, const std::string& app_id, policy::FunctionalIdType& group_types));
+  MOCK_CONST_METHOD2(CheckModuleType, bool(const PTString& app_id,
+                                            policy_table::ModuleType module));
+  MOCK_CONST_METHOD0(CheckParameters, bool());
 };
 
 }  // namespace policy

--- a/src/components/policy/test/policy_manager_impl_test.cc
+++ b/src/components/policy/test/policy_manager_impl_test.cc
@@ -344,11 +344,11 @@ TEST_F(PolicyManagerImplTest, ResetAccessBySubject) {
 }
 
 TEST_F(PolicyManagerImplTest, ResetAccessByObject) {
-  Object obj = {"group1", 1};
+  Object obj = {policy_table::MT_RADIO};
 
   EXPECT_CALL(*access_remote, Reset(obj));
 
-  manager->ResetAccess("group1", 1);
+  manager->ResetAccessByModule("RADIO");
 }
 
 TEST_F(PolicyManagerImplTest, SetRemoteControl_Enable) {
@@ -365,29 +365,29 @@ TEST_F(PolicyManagerImplTest, SetRemoteControl_Disable) {
 
 TEST_F(PolicyManagerImplTest, SetAccess_Allow) {
   Subject who = {"dev1", "12345"};
-  Object what = {"group1", 1};
+  Object what = {policy_table::MT_CLIMATE};
 
   EXPECT_CALL(*listener, OnCurrentDeviceIdUpdateRequired("12345")).
       WillOnce(Return("dev1"));
   EXPECT_CALL(*access_remote, Allow(who, what));
 
-  manager->SetAccess("12345", "group1", 1, true);
+  manager->SetAccess("12345", "CLIMATE", true);
 }
 
 TEST_F(PolicyManagerImplTest, SetAccess_Deny) {
   Subject who = {"dev1", "12345"};
-  Object what = {"group1", 1};
+  Object what = {policy_table::MT_RADIO};
 
   EXPECT_CALL(*listener, OnCurrentDeviceIdUpdateRequired("12345")).
       WillOnce(Return("dev1"));
   EXPECT_CALL(*access_remote, Deny(who, what));
 
-  manager->SetAccess("12345", "group1", 1, false);
+  manager->SetAccess("12345", "RADIO", false);
 }
 
 TEST_F(PolicyManagerImplTest, CheckAccess_PrimaryDevice) {
   Subject who {"dev1", "12345"};
-  Object what {"group1", 2};
+  Object what {policy_table::MT_CLIMATE};
 
   EXPECT_CALL(*listener, OnCurrentDeviceIdUpdateRequired("12345")).
       WillOnce(Return("dev1"));
@@ -399,7 +399,7 @@ TEST_F(PolicyManagerImplTest, CheckAccess_PrimaryDevice) {
   EXPECT_CALL(*access_remote, Allow(who, what));
 
   EXPECT_EQ(TypeAccess::kAllowed,
-            manager->CheckAccess("12345", "rpc1", RemoteControlParams(), 2));
+            manager->CheckAccess("12345", "CLIMATE", RemoteControlParams(), 2));
 }
 
 TEST_F(PolicyManagerImplTest, CheckAccess_DisabledRremoteControl) {
@@ -428,7 +428,7 @@ TEST_F(PolicyManagerImplTest, CheckAccess_UnknownRPC) {
 
 TEST_F(PolicyManagerImplTest, CheckAccess_Result) {
   Subject who = {"dev1", "12345"};
-  Object what = {"group1", 2};
+  Object what = {policy_table::MT_RADIO};
 
   EXPECT_CALL(*listener, OnCurrentDeviceIdUpdateRequired("12345")).
       WillOnce(Return("dev1"));
@@ -446,7 +446,7 @@ TEST_F(PolicyManagerImplTest, CheckAccess_Result) {
 TEST_F(PolicyManagerImplTest, TwoDifferentDevice) {
   Subject who1 = {"dev1", "12345"};
   Subject who2 = {"dev2", "123456"};
-  Object what = {"group1", 1};
+  Object what = {policy_table::MT_RADIO};
 
   EXPECT_CALL(*listener, OnCurrentDeviceIdUpdateRequired("12345")).
       WillOnce(Return("dev1"));

--- a/src/components/policy/test/policy_manager_impl_test.cc
+++ b/src/components/policy/test/policy_manager_impl_test.cc
@@ -391,9 +391,11 @@ TEST_F(PolicyManagerImplTest, CheckAccess_PrimaryDevice) {
 
   EXPECT_CALL(*listener, OnCurrentDeviceIdUpdateRequired("12345")).
       WillOnce(Return("dev1"));
+  EXPECT_CALL(*access_remote,
+              CheckModuleType("12345", policy_table::MT_CLIMATE)).
+      WillOnce(Return(true));
+  EXPECT_CALL(*access_remote, CheckParameters()).WillOnce(Return(true));
   EXPECT_CALL(*access_remote, IsPrimaryDevice("dev1")).WillOnce(Return(true));
-  EXPECT_CALL(*access_remote, FindGroup(who, "rpc1", RemoteControlParams())).
-      WillOnce(Return("group1"));
   EXPECT_CALL(*access_remote, Check(who, what)).
       WillOnce(Return(TypeAccess::kManual));
   EXPECT_CALL(*access_remote, Allow(who, what));
@@ -405,25 +407,15 @@ TEST_F(PolicyManagerImplTest, CheckAccess_PrimaryDevice) {
 TEST_F(PolicyManagerImplTest, CheckAccess_DisabledRremoteControl) {
   EXPECT_CALL(*listener, OnCurrentDeviceIdUpdateRequired("12345")).
       WillOnce(Return("dev1"));
+  EXPECT_CALL(*access_remote,
+              CheckModuleType("12345", policy_table::MT_RADIO)).
+      WillOnce(Return(true));
+  EXPECT_CALL(*access_remote, CheckParameters()).WillOnce(Return(true));
   EXPECT_CALL(*access_remote, IsPrimaryDevice("dev1")).WillOnce(Return(false));
   EXPECT_CALL(*access_remote, IsEnabled()).WillOnce(Return(false));
 
   EXPECT_EQ(TypeAccess::kDisallowed,
-            manager->CheckAccess("12345", "rpc1", RemoteControlParams(), 2));
-}
-
-TEST_F(PolicyManagerImplTest, CheckAccess_UnknownRPC) {
-  Subject who = {"dev1", "12345"};
-
-  EXPECT_CALL(*listener, OnCurrentDeviceIdUpdateRequired("12345")).
-      WillOnce(Return("dev1"));
-  EXPECT_CALL(*access_remote, IsPrimaryDevice("dev1")).WillOnce(Return(false));
-  EXPECT_CALL(*access_remote, IsEnabled()).WillOnce(Return(true));
-  EXPECT_CALL(*access_remote, FindGroup(who, "rpc1", RemoteControlParams())).
-      WillOnce(Return(PTString()));
-
-  EXPECT_EQ(TypeAccess::kDisallowed,
-            manager->CheckAccess("12345", "rpc1", RemoteControlParams(), 2));
+            manager->CheckAccess("12345", "RADIO", RemoteControlParams(), 2));
 }
 
 TEST_F(PolicyManagerImplTest, CheckAccess_Result) {
@@ -432,15 +424,17 @@ TEST_F(PolicyManagerImplTest, CheckAccess_Result) {
 
   EXPECT_CALL(*listener, OnCurrentDeviceIdUpdateRequired("12345")).
       WillOnce(Return("dev1"));
+  EXPECT_CALL(*access_remote,
+              CheckModuleType("12345", policy_table::MT_RADIO)).
+      WillOnce(Return(true));
+  EXPECT_CALL(*access_remote, CheckParameters()).WillOnce(Return(true));
   EXPECT_CALL(*access_remote, IsPrimaryDevice("dev1")).WillOnce(Return(false));
   EXPECT_CALL(*access_remote, IsEnabled()).WillOnce(Return(true));
-  EXPECT_CALL(*access_remote, FindGroup(who, "rpc1", RemoteControlParams())).
-      WillOnce(Return("group1"));
   EXPECT_CALL(*access_remote, Check(who, what)).
       WillOnce(Return(TypeAccess::kAllowed));
 
   EXPECT_EQ(TypeAccess::kAllowed,
-            manager->CheckAccess("12345", "rpc1", RemoteControlParams(), 2));
+            manager->CheckAccess("12345", "RADIO", RemoteControlParams(), 2));
 }
 
 TEST_F(PolicyManagerImplTest, TwoDifferentDevice) {
@@ -450,26 +444,30 @@ TEST_F(PolicyManagerImplTest, TwoDifferentDevice) {
 
   EXPECT_CALL(*listener, OnCurrentDeviceIdUpdateRequired("12345")).
       WillOnce(Return("dev1"));
+  EXPECT_CALL(*access_remote,
+              CheckModuleType("12345", policy_table::MT_RADIO)).
+      WillOnce(Return(true));
+  EXPECT_CALL(*access_remote, CheckParameters()).Times(2).
+      WillRepeatedly(Return(true));
   EXPECT_CALL(*access_remote, IsPrimaryDevice("dev1")).WillOnce(Return(true));
-  EXPECT_CALL(*access_remote, FindGroup(who1, "rpc1", RemoteControlParams())).
-      WillOnce(Return("group1"));
   EXPECT_CALL(*access_remote, Check(who1, what)).
       WillOnce(Return(TypeAccess::kManual));
   EXPECT_CALL(*access_remote, Allow(who1, what));
 
   EXPECT_CALL(*listener, OnCurrentDeviceIdUpdateRequired("123456")).
       WillOnce(Return("dev2"));
+  EXPECT_CALL(*access_remote,
+              CheckModuleType("123456", policy_table::MT_RADIO)).
+      WillOnce(Return(true));
   EXPECT_CALL(*access_remote, IsPrimaryDevice("dev2")).WillOnce(Return(false));
   EXPECT_CALL(*access_remote, IsEnabled()).WillOnce(Return(true));
-  EXPECT_CALL(*access_remote, FindGroup(who2, "rpc1", RemoteControlParams())).
-      WillOnce(Return("group1"));
   EXPECT_CALL(*access_remote, Check(who2, what)).
         WillOnce(Return(TypeAccess::kDisallowed));
 
   EXPECT_EQ(TypeAccess::kAllowed,
-            manager->CheckAccess("12345", "rpc1", RemoteControlParams(), 1));
+            manager->CheckAccess("12345", "RADIO", RemoteControlParams(), 1));
   EXPECT_EQ(TypeAccess::kDisallowed,
-              manager->CheckAccess("123456", "rpc1", RemoteControlParams(), 1));
+              manager->CheckAccess("123456", "RADIO", RemoteControlParams(), 1));
 }
 #endif  // SDL_REMOTE_CONTROL
 


### PR DESCRIPTION
**Implemented:**
11. In case "moduleType" in app's assigned policies has one or more valid values, PoliciesManager must allow app's remote-control RPCs that contain only the listed value(s) of "moduleType" param.
12. In case "moduleType" in app's assigned policies has an empty array, PoliciesManager must allow app's remote-control RPCs that contain any of "moduleType" param.
13. In case "moduleType" does not exist in app's assigned policies, PoliciesManager must disallow app's remote-control RPCs that contain any of "moduleType" param.