### PR TITLE
REVSDL-1048: Fix name of user consent for passangers` devices

### DIFF
--- a/src/components/policy/src/policy/policy_table/table_struct/types.cc
+++ b/src/components/policy/src/policy/policy_table/table_struct/types.cc
@@ -329,7 +329,7 @@ ModuleConfig::ModuleConfig(const Json::Value* value__)
     vehicle_make(impl::ValueMember(value__, "vehicle_make")),
     vehicle_model(impl::ValueMember(value__, "vehicle_model")),
     vehicle_year(impl::ValueMember(value__, "vehicle_year")),
-    user_consent_passengerRC(impl::ValueMember(value__, "user_consent_passengerRC")),
+    user_consent_passengersRC(impl::ValueMember(value__, "user_consent_passengersRC")),
     country_consent_passengersRC(impl::ValueMember(value__, "country_consent_passengersRC")) {
 }
 Json::Value ModuleConfig::ToJsonValue() const {
@@ -346,7 +346,7 @@ Json::Value ModuleConfig::ToJsonValue() const {
   impl::WriteJsonField("vehicle_make", vehicle_make, &result__);
   impl::WriteJsonField("vehicle_model", vehicle_model, &result__);
   impl::WriteJsonField("vehicle_year", vehicle_year, &result__);
-  impl::WriteJsonField("user_consent_passengerRC", user_consent_passengerRC, &result__);
+  impl::WriteJsonField("user_consent_passengersRC", user_consent_passengersRC, &result__);
   impl::WriteJsonField("country_consent_passengersRC", country_consent_passengersRC, &result__);
   return result__;
 }
@@ -387,7 +387,7 @@ bool ModuleConfig::is_valid() const {
   if (!vehicle_year.is_valid()) {
     return false;
   }
-  if (!user_consent_passengerRC.is_valid()) {
+  if (!user_consent_passengersRC.is_valid()) {
     return false;
   }
   if (!country_consent_passengersRC.is_valid()) {
@@ -440,7 +440,7 @@ bool ModuleConfig::struct_empty() const {
   if (vehicle_year.is_initialized()) {
     return false;
   }
-  if (user_consent_passengerRC.is_initialized()) {
+  if (user_consent_passengersRC.is_initialized()) {
     return false;
   }
   if (country_consent_passengersRC.is_initialized()) {
@@ -489,8 +489,8 @@ void ModuleConfig::ReportErrors(rpc::ValidationReport* report__) const {
   if (!vehicle_year.is_valid()) {
     vehicle_year.ReportErrors(&report__->ReportSubobject("vehicle_year"));
   }
-  if (!user_consent_passengerRC.is_valid()) {
-    user_consent_passengerRC.ReportErrors(&report__->ReportSubobject("user_consent_passengerRC"));
+  if (!user_consent_passengersRC.is_valid()) {
+    user_consent_passengersRC.ReportErrors(&report__->ReportSubobject("user_consent_passengersRC"));
   }
   if (!country_consent_passengersRC.is_valid()) {
     country_consent_passengersRC.ReportErrors(&report__->ReportSubobject("country_consent_passengersRC"));
@@ -511,8 +511,8 @@ void ModuleConfig::ReportErrors(rpc::ValidationReport* report__) const {
       ommited_field_report = &report__->ReportSubobject("vehicle_model");
       ommited_field_report->set_validation_info(validation_info);
     }
-    if (user_consent_passengerRC.is_initialized()) {
-      ommited_field_report = &report__->ReportSubobject("user_consent_passengerRC");
+    if (user_consent_passengersRC.is_initialized()) {
+      ommited_field_report = &report__->ReportSubobject("user_consent_passengersRC");
       ommited_field_report->set_validation_info(validation_info);
     }
     if (country_consent_passengersRC.is_initialized()) {
@@ -536,7 +536,7 @@ void ModuleConfig::SetPolicyTableType(PolicyTableType pt_type) {
   vehicle_make.SetPolicyTableType(pt_type);
   vehicle_model.SetPolicyTableType(pt_type);
   vehicle_year.SetPolicyTableType(pt_type);
-  user_consent_passengerRC.SetPolicyTableType(pt_type);
+  user_consent_passengersRC.SetPolicyTableType(pt_type);
   country_consent_passengersRC.SetPolicyTableType(pt_type);
 }
 

--- a/src/components/policy/src/policy/policy_table/table_struct/types.h
+++ b/src/components/policy/src/policy/policy_table/table_struct/types.h
@@ -140,7 +140,7 @@ struct ModuleConfig : CompositeType {
     Optional< String<1, 100> > vehicle_model;
     Optional< String<4, 4> > vehicle_year;
     Optional< String<0, 65535> > certificate;
-    Optional< Boolean > user_consent_passengerRC;
+    Optional< Boolean > user_consent_passengersRC;
     Optional< Boolean > country_consent_passengersRC;
   public:
     ModuleConfig();

--- a/src/components/policy/src/policy/src/access_remote_impl.cc
+++ b/src/components/policy/src/policy/src/access_remote_impl.cc
@@ -161,8 +161,8 @@ void AccessRemoteImpl::Init() {
   country_consent_ = !config.country_consent_passengersRC.is_initialized()
       || *config.country_consent_passengersRC;
   enabled_ = country_consent_
-      && (!config.user_consent_passengerRC.is_initialized()
-          || *config.user_consent_passengerRC);
+      && (!config.user_consent_passengersRC.is_initialized()
+          || *config.user_consent_passengersRC);
 
   const DeviceData& devices = *cache_->pt_->policy_table.device_data;
   DeviceData::const_iterator d = std::find_if(devices.begin(), devices.end(),
@@ -267,7 +267,7 @@ void AccessRemoteImpl::Disable() {
 
 void AccessRemoteImpl::set_enabled(bool value) {
   enabled_ = country_consent_ && value;
-  *cache_->pt_->policy_table.module_config.user_consent_passengerRC = value;
+  *cache_->pt_->policy_table.module_config.user_consent_passengersRC = value;
   cache_->Backup();
 }
 

--- a/src/components/policy/src/policy/src/sql_pt_queries.cc
+++ b/src/components/policy/src/policy/src/sql_pt_queries.cc
@@ -75,7 +75,7 @@ const std::string kCreateSchema =
   "  `vehicle_make` VARCHAR(45), "
   "  `vehicle_model` VARCHAR(45), "
   "  `vehicle_year` VARCHAR(4),"
-  "  `user_consent_passengerRC` BOOL,"
+  "  `user_consent_passengersRC` BOOL,"
   "  `country_consent_passengersRC` BOOL "
   "); "
   "CREATE TABLE IF NOT EXISTS `functional_group`( "
@@ -569,7 +569,7 @@ const std::string kUpdateModuleConfig =
   "  `exchange_after_x_kilometers` = ?, `exchange_after_x_days` = ?, "
   "  `timeout_after_x_seconds` = ?, `vehicle_make` = ?, "
   "  `vehicle_model` = ?, `vehicle_year` = ?, "
-  "  `user_consent_passengerRC` = ?, `country_consent_passengersRC` = ?";
+  "  `user_consent_passengersRC` = ?, `country_consent_passengersRC` = ?";
 
 const std::string kInsertEndpoint =
   "INSERT INTO `endpoint` (`service`, `url`, `application_id`) "
@@ -624,7 +624,7 @@ const std::string kSelectModuleConfig =
   " `exchange_after_x_kilometers`, `exchange_after_x_days`, "
   " `timeout_after_x_seconds`, `vehicle_make`,"
   " `vehicle_model`, `vehicle_year`, "
-  " `user_consent_passengerRC` , `country_consent_passengersRC` "
+  " `user_consent_passengersRC` , `country_consent_passengersRC` "
   " FROM `module_config`";
 
 const std::string kSelectEndpoints =

--- a/src/components/policy/src/policy/src/sql_pt_representation.cc
+++ b/src/components/policy/src/policy/src/sql_pt_representation.cc
@@ -483,7 +483,7 @@ void SQLPTRepresentation::GatherModuleConfig(
     *config->vehicle_make = query.GetString(5);
     *config->vehicle_model = query.GetString(6);
     *config->vehicle_year = query.GetString(7);
-    *config->user_consent_passengerRC = query.IsNull(8) ? true :
+    *config->user_consent_passengersRC = query.IsNull(8) ? true :
         query.GetBoolean(8);
     *config->country_consent_passengersRC = query.IsNull(9) ? true :
         query.GetBoolean(9);
@@ -1048,8 +1048,8 @@ bool SQLPTRepresentation::SaveModuleConfig(
   query.Bind(6, *(config.vehicle_model)) : query.Bind(6);
   config.vehicle_year.is_initialized() ?
   query.Bind(7, *(config.vehicle_year)) : query.Bind(7);
-  config.user_consent_passengerRC.is_initialized() ?
-      query.Bind(8, *(config.user_consent_passengerRC)) : query.Bind(8);
+  config.user_consent_passengersRC.is_initialized() ?
+      query.Bind(8, *(config.user_consent_passengersRC)) : query.Bind(8);
   config.country_consent_passengersRC.is_initialized() ?
       query.Bind(9, *(config.country_consent_passengersRC)) : query.Bind(9);
 

--- a/src/components/policy/test/sql_pt_representation_test.cc
+++ b/src/components/policy/test/sql_pt_representation_test.cc
@@ -524,7 +524,7 @@ TEST_F(SQLPTRepresentationTest, GenerateSnapshot_SetPolicyTable_SnapshotIsPresen
   utils::SharedPtr<policy_table::Table> snapshot = reps->GenerateSnapshot();
   snapshot->SetPolicyTableType(rpc::policy_table_interface_base::PT_SNAPSHOT);
 
-  module_config["user_consent_passengerRC"] = Json::Value(true);
+  module_config["user_consent_passengersRC"] = Json::Value(true);
   module_config["country_consent_passengersRC"] = Json::Value(true);
   policy_table["device_data"] = Json::Value(Json::objectValue);
   consumer_friendly_messages.removeMember("messages");


### PR DESCRIPTION
Changed name of field in policy table.
user_consent_passengerRC -> user_consent_passenger**s**RC