### PR TITLE
REVSDL-1303: implement ask driver again if before access was denied

### DIFF
--- a/src/components/can_cooperation/src/command/base_command_request.cc
+++ b/src/components/can_cooperation/src/command/base_command_request.cc
@@ -418,17 +418,15 @@ void BaseCommandRequest::ProcessAccessResponse(
 
   // Check the actual User's answer.
   if (allowed) {
+    Json::Value request;
+    reader.parse(message_->json_message(), request);
+    std::string module = ModuleType(request);
+    LOG4CXX_DEBUG(
+        logger_,
+        "Setting allowed access for " << app_->app_id() << " for " << module);
+    service_->SetAccess(app_->app_id(), module, allowed);
     Execute();  // run child's logic
-  }
-
-  Json::Value request;
-  reader.parse(message_->json_message(), request);
-  std::string module = ModuleType(request);
-  LOG4CXX_DEBUG(logger_, "Setting allowed access for " << app_->app_id()
-    << " for " << module);
-  service_->SetAccess(app_->app_id(), module, allowed);
-
-  if (!allowed) {
+  } else {
     SendResponse(false, result_codes::kUserDisallowed, "");
   }
 }


### PR DESCRIPTION
**Implemented:**
In case the application sends a valid rc-RPC with <interiorZone>, <moduleType> and <params> allowed by app's assigned policies
- and "equipment" section of policies database contains this RPC name with <params> in <moduleType> in "driver_allow" sub-section of <interiorZone> section
- and the permission for this app&<interiorZone>&<moduleType> was denied either by the driver or by timeout or erroneous HMI's response
- RSDL must send the RC.GetInteriorVehicleDataConsent for getting driver's allowance to the vehicle (HMI). 