### PR TITLE
Feature/revsdl 1338 inform hmi none level

### DIFF
--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -3024,11 +3024,9 @@ void ApplicationManagerImpl::ChangeAppsHMILevel(uint32_t app_id,
   if (old_level != level) {
     app->set_hmi_level(level);
     OnHMILevelChanged(app_id, old_level, level);
-#ifdef SDL_REMOTE_CONTROL
-    //  TODO(PV): make distinction between SDL/plugin apps
-    MessageHelper::SendActivateAppToHMI(app_id,
-      static_cast<hmi_apis::Common_HMILevel::eType>(level), true);
-#endif
+
+    functional_modules::PluginManager::instance()->OnAppHMILevelChanged(app,
+      old_level);
   } else {
     LOG4CXX_WARN(logger_, "Redudant changing HMI level : " << level);
   }

--- a/src/components/can_cooperation/include/can_cooperation/can_module.h
+++ b/src/components/can_cooperation/include/can_cooperation/can_module.h
@@ -107,6 +107,14 @@ class CANModule : public functional_modules::GenericModule,
   bool IsAppForPlugin(
       application_manager::ApplicationSharedPtr app);
 
+  /*
+   * @brief Notify about change of HMILevel of plugin's app
+   * @param app App with new HMILevel
+   * @param old_level Old HMILevel of app
+   */
+  void OnAppHMILevelChanged(application_manager::ApplicationSharedPtr app,
+    mobile_apis::HMILevel::eType old_level);
+
  protected:
   /**
    * @brief Remove extension for all applications

--- a/src/components/can_cooperation/src/can_module.cc
+++ b/src/components/can_cooperation/src/can_module.cc
@@ -348,19 +348,32 @@ void CANModule::RemoveAppExtension(uint32_t app_id) {
 }
 
 bool CANModule::IsAppForPlugin(
-  application_manager::ApplicationSharedPtr app) {
-  if (app->app_types()) {
-    std::vector<int> hmi_types =
-      application_manager::SmartObjToArrayInt(app->app_types());
-    if (hmi_types.end() != std::find(hmi_types.begin(), hmi_types.end(),
+    application_manager::ApplicationSharedPtr app) {
+  application_manager::AppExtensionPtr app_extension = app->QueryInterface(
+    GetModuleID());
+  if (!app_extension) {
+    if (app->app_types()) {
+      std::vector<int> hmi_types =
+        application_manager::SmartObjToArrayInt(app->app_types());
+      if (hmi_types.end() !=
+                  std::find(hmi_types.begin(), hmi_types.end(),
                             mobile_apis::AppHMIType::eType::REMOTE_CONTROL)) {
-      CANAppExtensionPtr can_app_extension = new CANAppExtension(GetModuleID());
-      app->AddExtension(can_app_extension);
-      service()->NotifyHMIAboutHMILevel(app, app->hmi_level());
-      return true;
+        CANAppExtensionPtr can_app_extension = new CANAppExtension(
+          GetModuleID());
+        app->AddExtension(can_app_extension);
+        service()->NotifyHMIAboutHMILevel(app, app->hmi_level());
+        return true;
+      }
     }
+    return false;
   }
-  return false;
+  return true;
+}
+
+void CANModule::OnAppHMILevelChanged(
+    application_manager::ApplicationSharedPtr app,
+    mobile_apis::HMILevel::eType) {
+  service()->NotifyHMIAboutHMILevel(app, app->hmi_level());
 }
 
 }  //  namespace can_cooperation

--- a/src/components/can_cooperation/src/can_module.cc
+++ b/src/components/can_cooperation/src/can_module.cc
@@ -373,6 +373,8 @@ bool CANModule::IsAppForPlugin(
 void CANModule::OnAppHMILevelChanged(
     application_manager::ApplicationSharedPtr app,
     mobile_apis::HMILevel::eType) {
+  LOG4CXX_DEBUG(logger_, "RSDL application " << app->name()
+        << " has changed hmi level to " << app->hmi_level());
   service()->NotifyHMIAboutHMILevel(app, app->hmi_level());
 }
 

--- a/src/components/can_cooperation/test/src/can_module_test.cc
+++ b/src/components/can_cooperation/test/src/can_module_test.cc
@@ -220,6 +220,7 @@ TEST_F(CanModuleTest, IsAppForPluginSuccess) {
   smart_objects::SmartObject obj(smart_objects::SmartType::SmartType_Array);
   obj[0] = 10;  //  REMOTE_CONTROL
   app_ptr->set_app_types(obj);
+  EXPECT_CALL(*mock_service, NotifyHMIAboutHMILevel(app_ptr, _)).Times(1);
   ASSERT_TRUE(module->IsAppForPlugin(app_ptr));
 }
 

--- a/src/components/functional_module/include/functional_module/generic_module.h
+++ b/src/components/functional_module/include/functional_module/generic_module.h
@@ -123,6 +123,15 @@ class GenericModule {
   virtual bool IsAppForPlugin(
       application_manager::ApplicationSharedPtr app) = 0;
 
+  /*
+   * @brief Notify about change of HMILevel of plugin's app
+   * @param app App with new HMILevel
+   * @param old_level Old HMILevel of app
+   */
+  virtual void OnAppHMILevelChanged(
+    application_manager::ApplicationSharedPtr app,
+    mobile_apis::HMILevel::eType old_level) = 0;
+
  protected:
   explicit GenericModule(ModuleID module_id);
   void NotifyObservers(ModuleObserver::Errors error);

--- a/src/components/functional_module/include/functional_module/plugin_manager.h
+++ b/src/components/functional_module/include/functional_module/plugin_manager.h
@@ -72,6 +72,15 @@ class PluginManager : public utils::Singleton<PluginManager>,
    */
   bool IsAppForPlugins(application_manager::ApplicationSharedPtr app);
 
+  /*
+   * @brief Notify plugins about change of HMILevel of app
+   * if app is related to plugin
+   * @param app App with new HMILevel
+   * @param old_level Old HMILevel of app
+   */
+  void OnAppHMILevelChanged(application_manager::ApplicationSharedPtr app,
+    mobile_apis::HMILevel::eType old_level);
+
  private:
   PluginManager();
   ~PluginManager();

--- a/src/components/functional_module/src/plugin_manager.cc
+++ b/src/components/functional_module/src/plugin_manager.cc
@@ -211,7 +211,6 @@ bool PluginManager::IsMessageForPlugin(application_manager::MessagePtr msg) {
   }
 }
 
-
 bool PluginManager::IsHMIMessageForPlugin(application_manager::MessagePtr msg) {
   DCHECK(msg);
   if (!msg) {
@@ -290,6 +289,23 @@ bool PluginManager::IsAppForPlugins(
     res = res || it->second->IsAppForPlugin(app);
   }
   return res;
+}
+
+void PluginManager::OnAppHMILevelChanged(
+    application_manager::ApplicationSharedPtr app,
+    mobile_apis::HMILevel::eType old_level) {
+  DCHECK(app);
+  if (!app) {
+    return;
+  }
+  for (PluginsIterator it = plugins_.begin(); plugins_.end() != it; ++it) {
+    if (it->second->IsAppForPlugin(app)) {
+      LOG4CXX_DEBUG(logger_, "Application " << app->name() << " of plugin "
+        << it->second->GetModuleID() << " has changed level from " << old_level
+        << " to " << app->hmi_level());
+      it->second->OnAppHMILevelChanged(app, old_level);
+    }
+  }
 }
 
 }  //  namespace functional_modules

--- a/src/components/functional_module/test/include/driver_generic_module_test.h
+++ b/src/components/functional_module/test/include/driver_generic_module_test.h
@@ -58,6 +58,10 @@ class DriverGenericModuleTest : public GenericModule {
   bool IsAppForPlugin(
       application_manager::ApplicationSharedPtr app) {return true;}
 
+  void OnAppHMILevelChanged(
+    application_manager::ApplicationSharedPtr,
+    mobile_apis::HMILevel::eType) {}
+
   const Observers& observers() {
     return observers_;
   }

--- a/src/components/functional_module/test/plugins/mock_generic_module.h
+++ b/src/components/functional_module/test/plugins/mock_generic_module.h
@@ -62,6 +62,9 @@ class MockGenericModule : public GenericModule {
       void(uint32_t app_id));
   MOCK_METHOD1(IsAppForPlugin, bool(
       application_manager::ApplicationSharedPtr app));
+  MOCK_METHOD2(OnAppHMILevelChanged, void(
+    application_manager::ApplicationSharedPtr app,
+    mobile_apis::HMILevel::eType old_level));
   MOCK_METHOD0(RemoveAppExtensions,
       void());
 };

--- a/src/components/functional_module/test/src/plugin_manager_test.cc
+++ b/src/components/functional_module/test/src/plugin_manager_test.cc
@@ -8,6 +8,9 @@
 using application_manager::Message;
 using application_manager::ProtocolVersion;
 using application_manager::MockService;
+using ::testing::NiceMock;
+using ::testing::Expectation;
+using ::testing::ReturnRef;
 
 namespace functional_modules {
 
@@ -134,6 +137,24 @@ TEST_F(PluginManagerTest, IsAppForPlugins) {
   application_manager::ApplicationSharedPtr app_ptr(app);
   EXPECT_CALL(*module, IsAppForPlugin(app_ptr)).Times(1);
   manager->IsAppForPlugins(app_ptr);
+}
+
+TEST_F(PluginManagerTest, OnAppHMILevelChanged) {
+  NiceMock<application_manager::MockApplication>* app =
+    new NiceMock<application_manager::MockApplication>();
+  application_manager::ApplicationSharedPtr app_ptr(app);
+
+  std::string name("name");
+  ON_CALL(*app, name()).WillByDefault(ReturnRef(name));
+  mobile_apis::HMILevel::eType level = mobile_apis::HMILevel::eType::HMI_NONE;
+  ON_CALL(*app, hmi_level()).WillByDefault(ReturnRef(level));
+
+  Expectation is_for_plugin = EXPECT_CALL(*module, IsAppForPlugin(app_ptr))
+    .WillOnce(Return(true));
+  EXPECT_CALL(*module, OnAppHMILevelChanged(app_ptr, _))
+    .Times(1)
+    .After(is_for_plugin);
+  manager->OnAppHMILevelChanged(app_ptr, mobile_apis::HMILevel::eType::HMI_FULL);
 }
 
 }  // namespace functional_modules


### PR DESCRIPTION
HMI Level of rc-application is changed to NONE due to its lifecycle on HMI; RSDL must inform via BC.ActivateApp (NONE ) to HMI