### PR TITLE
Fix/revsdl 1368 app on primary dev fix

### DIFF
--- a/src/components/application_manager/include/application_manager/core_service.h
+++ b/src/components/application_manager/include/application_manager/core_service.h
@@ -114,6 +114,11 @@ class CoreService : public Service {
    */
   virtual void SetPrimaryDevice(const uint32_t dev_id);
 
+  /*
+   * Return id of primary device
+   */
+  uint32_t PrimaryDevice() const;
+
   /**
    * Sets mode of remote control (on/off)
    * @param enabled true if remote control is turned on

--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -135,6 +135,11 @@ class PolicyHandler :
    */
   void SetPrimaryDevice(const PTString& dev_id);
 
+  /*
+   * Return id of primary device
+   */
+  uint32_t PrimaryDevice() const;
+
   /**
    * Sets mode of remote control (on/off)
    * @param enabled true if remote control is turned on

--- a/src/components/application_manager/include/application_manager/service.h
+++ b/src/components/application_manager/include/application_manager/service.h
@@ -35,7 +35,7 @@
 
 #include <string>
 #include <sstream>
-
+#include <vector>
 #include "application_manager/application.h"
 #include "application_manager/message.h"
 

--- a/src/components/application_manager/include/application_manager/service.h
+++ b/src/components/application_manager/include/application_manager/service.h
@@ -113,6 +113,11 @@ class Service {
    */
   virtual void SetPrimaryDevice(const uint32_t dev_id) = 0;
 
+  /*
+   * Return id of primary device
+   */
+  virtual uint32_t PrimaryDevice() const = 0;
+
   /**
    * Sets mode of remote control (on/off)
    * @param enabled true if remote control is turned on

--- a/src/components/application_manager/src/core_service.cc
+++ b/src/components/application_manager/src/core_service.cc
@@ -131,6 +131,13 @@ void CoreService::SetPrimaryDevice(const uint32_t dev_id) {
 #endif  // SDL_REMOTE_CONTROL
 }
 
+uint32_t CoreService::PrimaryDevice() const {
+#ifdef SDL_REMOTE_CONTROL
+  return policy::PolicyHandler::instance()->PrimaryDevice();
+#endif  // SDL_REMOTE_CONTROL
+  return 0;
+}
+
 void CoreService::SetRemoteControl(bool enabled) {
 #ifdef SDL_REMOTE_CONTROL
   policy::PolicyHandler::instance()->SetRemoteControl(enabled);

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -1421,14 +1421,22 @@ void PolicyHandler::SetPrimaryDevice(const PTString& dev_id) {
   }
 }
 
+uint32_t PolicyHandler::PrimaryDevice() const {
+  PTString device_id = policy_manager_->PrimaryDevice();
+  connection_handler::DeviceHandle device_handle;
+  if (ApplicationManagerImpl::instance()->connection_handler()
+        ->GetDeviceID(device_id, &device_handle)) {
+    return device_handle;
+  } else {
+    return 0;
+  }
+}
+
 void PolicyHandler::SetRemoteControl(bool enabled) {
   POLICY_LIB_CHECK_VOID();
   policy_manager_->SetRemoteControl(enabled);
 
-  PTString device_id = policy_manager_->PrimaryDevice();
-  connection_handler::DeviceHandle device_handle;
-    ApplicationManagerImpl::instance()->connection_handler()
-        ->GetDeviceID(device_id, &device_handle);
+  connection_handler::DeviceHandle device_handle = PrimaryDevice();
 
   ApplicationManagerImpl::ApplicationListAccessor accessor;
   for (ApplicationManagerImpl::ApplictionSetConstIt i = accessor.begin();

--- a/src/components/can_cooperation/include/can_cooperation/policy_helper.h
+++ b/src/components/can_cooperation/include/can_cooperation/policy_helper.h
@@ -34,6 +34,7 @@
 #define SRC_COMPONENTS_CAN_COOPERATION_INCLUDE_CAN_COOPERATION_POLICY_HELPER_H_
 
 #include <string>
+#include "application_manager/application.h"
 
 namespace can_cooperation {
 
@@ -41,6 +42,13 @@ class PolicyHelper {
  public:
   static void OnRSDLFunctionalityAllowing(bool allowed);
   static void SetPrimaryDevice(const uint32_t device_handle);
+  static void SetIsAppOnPrimaryDevice(
+    application_manager::ApplicationSharedPtr app);
+
+private:
+  static void MarkAppOnPrimaryDevice(
+    application_manager::ApplicationSharedPtr app,
+    const uint32_t device_handle);
 };
 
 }  //  namespace can_cooperation

--- a/src/components/can_cooperation/include/can_cooperation/policy_helper.h
+++ b/src/components/can_cooperation/include/can_cooperation/policy_helper.h
@@ -45,7 +45,7 @@ class PolicyHelper {
   static void SetIsAppOnPrimaryDevice(
     application_manager::ApplicationSharedPtr app);
 
-private:
+ private:
   static void MarkAppOnPrimaryDevice(
     application_manager::ApplicationSharedPtr app,
     const uint32_t device_handle);
@@ -53,4 +53,4 @@ private:
 
 }  //  namespace can_cooperation
 
-#endif  //  SRC_COMPONENTS_CAN_COOPERATION_INCLUDE_CAN_COOPERATION_POLICY_HELPER_H_
+#endif  // SRC_COMPONENTS_CAN_COOPERATION_INCLUDE_CAN_COOPERATION_POLICY_HELPER_H_

--- a/src/components/can_cooperation/src/can_module.cc
+++ b/src/components/can_cooperation/src/can_module.cc
@@ -362,6 +362,7 @@ bool CANModule::IsAppForPlugin(
           GetModuleID());
         app->AddExtension(can_app_extension);
         service()->NotifyHMIAboutHMILevel(app, app->hmi_level());
+        PolicyHelper::SetIsAppOnPrimaryDevice(app);
         return true;
       }
     }

--- a/src/components/can_cooperation/src/can_module.cc
+++ b/src/components/can_cooperation/src/can_module.cc
@@ -121,7 +121,8 @@ ProcessResult CANModule::ProcessMessage(application_manager::MessagePtr msg) {
   }
 
   msg->set_function_name(MessageHelper::GetMobileAPIName(
-                           static_cast<functional_modules::MobileFunctionID>(msg->function_id())));
+                          static_cast<functional_modules::MobileFunctionID>(
+                            msg->function_id())));
 
   commands::Command* command = MobileCommandFactory::CreateCommand(msg);
   if (command) {
@@ -272,8 +273,9 @@ functional_modules::ProcessResult CANModule::HandleMessage(
       }
 
       int32_t func_id = msg->function_id();
-      std::string func_name = MessageHelper::GetMobileAPIName(
-                                static_cast<functional_modules::MobileFunctionID>(func_id));
+      std::string func_name =
+        MessageHelper::GetMobileAPIName(
+                  static_cast<functional_modules::MobileFunctionID>(func_id));
       msg->set_function_name(func_name);
 
       NotifyMobiles(msg);

--- a/src/components/can_cooperation/test/include/mock_service.h
+++ b/src/components/can_cooperation/test/include/mock_service.h
@@ -70,6 +70,7 @@ class MockService : public Service {
   MOCK_METHOD1(ResetAccess, void(const ApplicationId& app_id));
   MOCK_METHOD1(ResetAccessByModule, void(const std::string& module));
   MOCK_METHOD1(SetPrimaryDevice, void(const uint32_t dev_id));
+  MOCK_CONST_METHOD0(PrimaryDevice, uint32_t());
   MOCK_METHOD1(SetRemoteControl, void(bool enabled));
   MOCK_CONST_METHOD0(IsRemoteControlAllowed, bool());
 };

--- a/src/components/can_cooperation/test/include/mock_service_some_impl.h
+++ b/src/components/can_cooperation/test/include/mock_service_some_impl.h
@@ -70,6 +70,7 @@ class MockServiceSomeImpl : public Service {
   MOCK_METHOD1(ResetAccess, void(const ApplicationId& app_id));
   MOCK_METHOD1(ResetAccessByModule, void(const std::string& module));
   MOCK_METHOD1(SetPrimaryDevice, void(const uint32_t dev_id));
+  MOCK_CONST_METHOD0(PrimaryDevice, uint32_t());
   MOCK_METHOD1(SetRemoteControl, void(bool enabled));
   MOCK_CONST_METHOD0(IsRemoteControlAllowed, bool());
 private:

--- a/src/components/functional_module/test/include/mock_service.h
+++ b/src/components/functional_module/test/include/mock_service.h
@@ -70,6 +70,7 @@ class MockService : public Service {
   MOCK_METHOD1(ResetAccess, void(const ApplicationId& app_id));
   MOCK_METHOD1(ResetAccessByModule, void(const std::string& module));
   MOCK_METHOD1(SetPrimaryDevice, void(const uint32_t dev_id));
+  MOCK_CONST_METHOD0(PrimaryDevice, uint32_t());
   MOCK_METHOD1(SetRemoteControl, void(bool enabled));
   MOCK_CONST_METHOD0(IsRemoteControlAllowed, bool());
 };


### PR DESCRIPTION
Fix for "RSDL does not assign BACKGROUND HMI level to application in LIMITED in case another application is activated on primary device."