### PR TITLE
REVSDL-1384: fixed wrong re-initialization of app in policies

### DIFF
--- a/src/components/policy/src/policy/src/policy_manager_impl.cc
+++ b/src/components/policy/src/policy/src/policy_manager_impl.cc
@@ -889,6 +889,8 @@ void PolicyManagerImpl::PromoteExistedApplication(
   if (kDeviceAllowed == device_consent
       && cache_->IsPredataPolicy(application_id)) {
     cache_->SetDefaultPolicy(application_id);
+  } else if (cache_->IsDefaultPolicy(application_id)) {
+    cache_->SetDefaultPolicy(application_id);
   }
 }
 


### PR DESCRIPTION
Policy Manager returns DISALLOWED if sending valid RPCs from passenger's device after RSDL restarted