### PR TITLE
REVSDL-1370

### DIFF
--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -1427,6 +1427,7 @@ void PolicyHandler::SetPrimaryDevice(const PTString& dev_id) {
 }
 
 uint32_t PolicyHandler::PrimaryDevice() const {
+  POLICY_LIB_CHECK(0);
   PTString device_id = policy_manager_->PrimaryDevice();
   connection_handler::DeviceHandle device_handle;
   if (ApplicationManagerImpl::instance()->connection_handler()
@@ -1459,6 +1460,7 @@ void PolicyHandler::SetRemoteControl(bool enabled) {
 }
 
 bool PolicyHandler::GetRemoteControl() const {
+  POLICY_LIB_CHECK(false);
   return policy_manager_->GetRemoteControl();
 }
 #endif  // SDL_REMOTE_CONTROL

--- a/src/components/can_cooperation/include/can_cooperation/commands/get_interior_vehicle_data_capabilities_request.h
+++ b/src/components/can_cooperation/include/can_cooperation/commands/get_interior_vehicle_data_capabilities_request.h
@@ -77,6 +77,7 @@ class GetInteriorVehicleDataCapabiliesRequest : public BaseCommandRequest {
 
  protected:
   virtual bool CheckAccess();
+  bool ReadCapabilitiesFromFile();
 };
 
 }  // namespace commands

--- a/src/components/can_cooperation/include/can_cooperation/validators/validator.h
+++ b/src/components/can_cooperation/include/can_cooperation/validators/validator.h
@@ -44,7 +44,7 @@ namespace validators {
 
 enum ValidationResult {
   SUCCESS,
-  INVALID_DATA,
+  INVALID_DATA
 };
 
 

--- a/src/components/can_cooperation/src/command/get_interior_vehicle_data_capabilities_request.cc
+++ b/src/components/can_cooperation/src/command/get_interior_vehicle_data_capabilities_request.cc
@@ -123,7 +123,6 @@ void GetInteriorVehicleDataCapabiliesRequest::OnEvent(
 
     if (!success) {
       //  Try to read capabilities from file.
-      //  TODO(PV): move to separate method
       if (ReadCapabilitiesFromFile()) {
         success = true;
         result_code = result_codes::kSuccess;

--- a/src/components/can_cooperation/src/command/on_interior_vehicle_data_notification.cc
+++ b/src/components/can_cooperation/src/command/on_interior_vehicle_data_notification.cc
@@ -96,7 +96,7 @@ bool OnInteriorVehicleDataNotification::Validate() {
       Validate(json)) {
     msg->set_json_message(json);
   } else {
-    LOG4CXX_INFO(logger_, "HMI notification validation failed!");
+    LOG4CXX_INFO(logger_, "Invalid notification from the vehicle!");
     return false;
   }
 

--- a/src/components/can_cooperation/src/module_helper.cc
+++ b/src/components/can_cooperation/src/module_helper.cc
@@ -135,19 +135,16 @@ functional_modules::ProcessResult ProcessSDLActivateApp(
           if (!new_app_ext) {
             return ProcessResult::CANNOT_PROCESS;
           }
-          if (!CANModule::instance()->service()->IsRemoteControlAllowed()) {
-            if (!new_app_ext->is_on_driver_device()) {
-              // Do not change HMI Level of app on passenger's device
-              // if Remote Functionality is disabled
-              application_manager::MessagePtr msg = ResponseToHMI(
-                value[json_keys::kId].asUInt(),
-                hmi_apis::Common_Result::GENERIC_ERROR,
-                functional_modules::hmi_api::sdl_activate_app);
+          if (!new_app_ext->is_on_driver_device()) {
+            // Do not change HMI Level of app on passenger's device
+            application_manager::MessagePtr msg = ResponseToHMI(
+              value[json_keys::kId].asUInt(),
+              hmi_apis::Common_Result::GENERIC_ERROR,
+              functional_modules::hmi_api::sdl_activate_app);
 
-              CANModule::instance()->service()->SendMessageToHMI(msg);
+            CANModule::instance()->service()->SendMessageToHMI(msg);
 
-              return ProcessResult::PROCESSED;
-            }
+            return ProcessResult::PROCESSED;
           }
         }
         CANAppExtensionPtr app_ext =

--- a/src/components/can_cooperation/src/module_helper.cc
+++ b/src/components/can_cooperation/src/module_helper.cc
@@ -146,18 +146,19 @@ functional_modules::ProcessResult ProcessSDLActivateApp(
 
             return ProcessResult::PROCESSED;
           }
-        }
-        CANAppExtensionPtr app_ext =
-          AppExtensionPtr::static_pointer_cast<CANAppExtension>(
-            applications[i]->QueryInterface(
-              CANModule::instance()->GetModuleID()));
-        DCHECK(app_ext);
-        if (!app_ext) {
-          continue;
-        }
-        if (applications[i]->hmi_level() == mobile_apis::HMILevel::HMI_LIMITED
-            && app_ext->is_on_driver_device()) {
-          limited_apps.push_back(applications[i]);
+        } else {
+          CANAppExtensionPtr app_ext =
+            AppExtensionPtr::static_pointer_cast<CANAppExtension>(
+              applications[i]->QueryInterface(
+                CANModule::instance()->GetModuleID()));
+          DCHECK(app_ext);
+          if (!app_ext) {
+            continue;
+          }
+          if (applications[i]->hmi_level() == mobile_apis::HMILevel::HMI_LIMITED
+              && app_ext->is_on_driver_device()) {
+            limited_apps.push_back(applications[i]);
+          }
         }
       }
       if (active_app == new_app) {

--- a/src/components/can_cooperation/src/validators/struct_validators/module_data_validator.cc
+++ b/src/components/can_cooperation/src/validators/struct_validators/module_data_validator.cc
@@ -83,7 +83,7 @@ ValidationResult ModuleDataValidator::Validate(const Json::Value& json,
                                               outgoing_json[kRadioControlData]);
   } else {
     if (enums_value::kRadio == outgoing_json[kModuleType].asString()) {
-      LOG4CXX_ERROR(logger_, "Incorrect combination of params (like RADIO with ClimateData)" );
+      LOG4CXX_ERROR(logger_, "Radio control data missed!" );
       return ValidationResult::INVALID_DATA;
     }
   }
@@ -96,6 +96,11 @@ ValidationResult ModuleDataValidator::Validate(const Json::Value& json,
     result = ClimateControlDataValidator::instance()->Validate(
                                              json[kClimateControlData],
                                              outgoing_json[kClimateControlData]);
+  } else {
+    if (enums_value::kClimate == outgoing_json[kModuleType].asString()) {
+      LOG4CXX_ERROR(logger_, "Climate control data missed!" );
+      return ValidationResult::INVALID_DATA;
+    }
   }
 
   return result;

--- a/src/components/policy/src/policy/include/policy/sql_pt_queries.h
+++ b/src/components/policy/src/policy/include/policy/sql_pt_queries.h
@@ -107,6 +107,7 @@ extern const std::string kDeleteRpc;
 extern const std::string kDeleteAppGroup;
 extern const std::string kDeleteAppGroupPrimary;
 extern const std::string kDeleteAppGroupNonPrimary;
+extern const std::string kDeleteModuleTypes;
 extern const std::string kDeleteApplication;
 extern const std::string kDeleteDevice;
 extern const std::string kDeleteAllDevices;

--- a/src/components/policy/src/policy/src/policy_manager_impl.cc
+++ b/src/components/policy/src/policy/src/policy_manager_impl.cc
@@ -889,6 +889,8 @@ void PolicyManagerImpl::PromoteExistedApplication(
   if (kDeviceAllowed == device_consent
       && cache_->IsPredataPolicy(application_id)) {
     cache_->SetDefaultPolicy(application_id);
+  } else if (cache_->IsDefaultPolicy(application_id)) {
+    cache_->SetDefaultPolicy(application_id);
   }
 }
 

--- a/src/components/policy/src/policy/src/sql_pt_queries.cc
+++ b/src/components/policy/src/policy/src/sql_pt_queries.cc
@@ -674,6 +674,8 @@ const std::string kDeleteAppGroupPrimary = "DELETE FROM `app_group_primary`";
 
 const std::string kDeleteAppGroupNonPrimary = "DELETE FROM `app_group_non_primary`";
 
+const std::string kDeleteModuleTypes = "DELETE FROM `module_type`";
+
 const std::string kSelectModuleConfig =
   "SELECT `preloaded_pt`, `exchange_after_x_ignition_cycles`, "
   " `exchange_after_x_kilometers`, `exchange_after_x_days`, "

--- a/src/components/policy/src/policy/src/sql_pt_representation.cc
+++ b/src/components/policy/src/policy/src/sql_pt_representation.cc
@@ -845,6 +845,10 @@ bool SQLPTRepresentation::SaveApplicationPolicies(
     LOG4CXX_WARN(logger_, "Incorrect delete from app_group_non_primary.");
     return false;
   }
+  if (!query_delete.Exec(sql_pt::kDeleteModuleTypes)) {
+    LOG4CXX_WARN(logger_, "Incorrect delete from module_type.");
+    return false;
+  }
 #endif  // SDL_REMOTE_CONTROL
   if (!query_delete.Exec(sql_pt::kDeleteApplication)) {
     LOG4CXX_WARN(logger_, "Incorrect delete from application.");


### PR DESCRIPTION
HMI's RPCs validation rules: doesn't validate when HMI responds non-corresponding-to-each-other moduleType and <module>ControlData