### PR TITLE
Fix/revsdl 1234 wrong json fix

### DIFF
--- a/src/components/can_cooperation/include/can_cooperation/commands/base_command_request.h
+++ b/src/components/can_cooperation/include/can_cooperation/commands/base_command_request.h
@@ -143,6 +143,13 @@ class BaseCommandRequest : public Command,
    */
   virtual bool Validate() = 0;
 
+  /*
+   * @brief Parses incoming string into Json
+   * @param parsed_mgs Resulting json object (must be valid pointer)
+   * @returns True if json string was valid false otherwise.
+   */
+  virtual bool ParseJsonString(Json::Value* parsed_msg);
+
   /**
    * @brief Interface method that is called whenever new event received
    * @param event The received event

--- a/src/components/can_cooperation/src/command/base_command_request.cc
+++ b/src/components/can_cooperation/src/command/base_command_request.cc
@@ -130,6 +130,21 @@ void  BaseCommandRequest::SendRequest(const char* function_id,
   }
 }
 
+bool BaseCommandRequest::ParseJsonString(Json::Value* parsed_msg) {
+  DCHECK(parsed_msg);
+  if (!parsed_msg) return false;
+
+  (*parsed_msg) = MessageHelper::StringToValue(message_->json_message());
+  if (Json::ValueType::nullValue == parsed_msg->type()) {
+    LOG4CXX_ERROR(logger_, "Invalid JSON received in " <<
+      message_->json_message());
+    SendResponse(false, result_codes::kInvalidData,
+                 "Mobile request validation failed!");
+    return false;
+  }
+  return true;
+}
+
 const char* BaseCommandRequest::GetMobileResultCode(
   const hmi_apis::Common_Result::eType& hmi_code) const {
   switch (hmi_code) {

--- a/src/components/can_cooperation/src/command/button_press_request.cc
+++ b/src/components/can_cooperation/src/command/button_press_request.cc
@@ -88,8 +88,10 @@ bool ButtonPressRequest::Validate() {
   LOG4CXX_AUTO_TRACE(logger_);
 
   Json::Value json;
+  if (!this->ParseJsonString(&json)) {
+    return false;
+  }
 
-  json = MessageHelper::StringToValue(message_->json_message());
   Json::Value outgoing_json;
 
   if (validators::ValidationResult::SUCCESS !=

--- a/src/components/can_cooperation/src/command/get_interior_vehicle_data_capabilities_request.cc
+++ b/src/components/can_cooperation/src/command/get_interior_vehicle_data_capabilities_request.cc
@@ -189,8 +189,9 @@ bool GetInteriorVehicleDataCapabiliesRequest::Validate() {
   LOG4CXX_AUTO_TRACE(logger_);
 
   Json::Value json;
-
-  json = MessageHelper::StringToValue(message_->json_message());
+  if (!this->ParseJsonString(&json)) {
+    return false;
+  }
   Json::Value outgoing_json;
 
   if (validators::ValidationResult::SUCCESS !=

--- a/src/components/can_cooperation/src/command/get_interior_vehicle_data_request.cc
+++ b/src/components/can_cooperation/src/command/get_interior_vehicle_data_request.cc
@@ -134,8 +134,10 @@ bool GetInteriorVehicleDataRequest::Validate() {
   LOG4CXX_AUTO_TRACE(logger_);
 
   Json::Value json;
+  if (!this->ParseJsonString(&json)) {
+    return false;
+  }
 
-  json = MessageHelper::StringToValue(message_->json_message());
   Json::Value outgoing_json;
 
   if (validators::ValidationResult::SUCCESS !=

--- a/src/components/can_cooperation/src/command/set_interior_vehicle_data_request.cc
+++ b/src/components/can_cooperation/src/command/set_interior_vehicle_data_request.cc
@@ -112,8 +112,10 @@ void SetInteriorVehicleDataRequest::OnEvent(
 bool SetInteriorVehicleDataRequest::Validate() {
 
   Json::Value json;
+  if (!this->ParseJsonString(&json)) {
+    return false;
+  }
 
-  json = MessageHelper::StringToValue(message_->json_message());
   Json::Value outgoing_json;
 
   if (validators::ValidationResult::SUCCESS !=


### PR DESCRIPTION
SDL: App's RPCs validation rules: don't validate Wrong Json when sending "GetInteriorVehicleDataCapabilities" RPC