### PR TITLE
Fix/validation internal rpcs fix

### DIFF
--- a/src/components/can_cooperation/include/can_cooperation/can_module_constants.h
+++ b/src/components/can_cooperation/include/can_cooperation/can_module_constants.h
@@ -120,7 +120,6 @@ const char kAddress[]        = "address";
 // Location struct
 
 // SongInfo struct
-const char kName[]     = "name";
 const char kArtist[]   = "artist";
 const char kGenre[]    = "genre";
 const char kAlbum[]    = "album";
@@ -184,6 +183,7 @@ const char kAllowed[]    = "allowed";
 
 // RC.OnSetDriversDevice notification
 const char kDevice[]     = "device";
+const char kName[]       = "name";
 // RC.OnSetDriversDevice notification
 
 // ButtonPress request

--- a/src/components/can_cooperation/src/can_module.cc
+++ b/src/components/can_cooperation/src/can_module.cc
@@ -259,7 +259,12 @@ functional_modules::ProcessResult CANModule::HandleMessage(
       } else if (functional_modules::hmi_api::on_set_drivers_device
           == function_name) {
         if (value.isMember(json_keys::kParams)) {
-          if (value[json_keys::kParams].isMember(message_params::kDevice)) {
+          if (value[json_keys::kParams].isMember(message_params::kDevice)
+            && value[json_keys::kParams][message_params::kDevice].isObject()
+            && value[json_keys::kParams][message_params::kDevice].isMember(json_keys::kId)
+            && value[json_keys::kParams][message_params::kDevice][json_keys::kId].isUInt()
+            && value[json_keys::kParams][message_params::kDevice].isMember(message_params::kName)
+            && value[json_keys::kParams][message_params::kDevice][message_params::kName].isString()) {
             PolicyHelper::SetPrimaryDevice(
               value[json_keys::kParams][message_params::kDevice]
               [json_keys::kId].asUInt());

--- a/src/components/can_cooperation/src/can_module.cc
+++ b/src/components/can_cooperation/src/can_module.cc
@@ -264,7 +264,7 @@ functional_modules::ProcessResult CANModule::HandleMessage(
           if (value[json_keys::kParams].isMember(message_params::kDevice)
             && value[json_keys::kParams][message_params::kDevice].isObject()
             && value[json_keys::kParams][message_params::kDevice].isMember(json_keys::kId)
-            && value[json_keys::kParams][message_params::kDevice][json_keys::kId].isUInt()
+            && value[json_keys::kParams][message_params::kDevice][json_keys::kId].isIntegral()
             && value[json_keys::kParams][message_params::kDevice].isMember(message_params::kName)
             && value[json_keys::kParams][message_params::kDevice][message_params::kName].isString()) {
             PolicyHelper::SetPrimaryDevice(

--- a/src/components/can_cooperation/src/can_module.cc
+++ b/src/components/can_cooperation/src/can_module.cc
@@ -246,7 +246,8 @@ functional_modules::ProcessResult CANModule::HandleMessage(
       } else if (functional_modules::hmi_api::on_reverse_apps_allowing
                  == function_name) {
         if (value.isMember(json_keys::kParams)) {
-          if (value[json_keys::kParams].isMember(message_params::kAllowed)) {
+          if (value[json_keys::kParams].isMember(message_params::kAllowed)
+                && value[json_keys::kParams][message_params::kAllowed].isBool()) {
             PolicyHelper::OnRSDLFunctionalityAllowing(
               value[json_keys::kParams][message_params::kAllowed].asBool());
           } else {

--- a/src/components/can_cooperation/src/can_module.cc
+++ b/src/components/can_cooperation/src/can_module.cc
@@ -246,6 +246,7 @@ functional_modules::ProcessResult CANModule::HandleMessage(
       } else if (functional_modules::hmi_api::on_reverse_apps_allowing
                  == function_name) {
         if (value.isMember(json_keys::kParams)) {
+          // TODO(VS): move validation to separate class
           if (value[json_keys::kParams].isMember(message_params::kAllowed)
                 && value[json_keys::kParams][message_params::kAllowed].isBool()) {
             PolicyHelper::OnRSDLFunctionalityAllowing(
@@ -259,6 +260,7 @@ functional_modules::ProcessResult CANModule::HandleMessage(
       } else if (functional_modules::hmi_api::on_set_drivers_device
           == function_name) {
         if (value.isMember(json_keys::kParams)) {
+          // TODO(VS): move validation to separate class
           if (value[json_keys::kParams].isMember(message_params::kDevice)
             && value[json_keys::kParams][message_params::kDevice].isObject()
             && value[json_keys::kParams][message_params::kDevice].isMember(json_keys::kId)

--- a/src/components/can_cooperation/src/command/base_command_request.cc
+++ b/src/components/can_cooperation/src/command/base_command_request.cc
@@ -411,7 +411,8 @@ void BaseCommandRequest::ProcessAccessResponse(
   bool allowed = ParseResultCode(value, result_code, info);
   // Check if valid successfull message has arrived
   if (allowed) {
-    if (value[kResult].isMember(message_params::kAllowed)) {
+    if (value[kResult].isMember(message_params::kAllowed)
+         && value[kResult][message_params::kAllowed].isBool()) {
       allowed = value[kResult][message_params::kAllowed].asBool();
     } else {
       allowed = false;

--- a/src/components/can_cooperation/test/src/can_module_test.cc
+++ b/src/components/can_cooperation/test/src/can_module_test.cc
@@ -307,6 +307,7 @@ TEST_F(CanModuleTest, ChangeDriverDevice) {
   value[json_keys::kParams] = Json::Value(Json::ValueType::objectValue);
   value[json_keys::kParams][message_params::kDevice] = Json::Value(Json::ValueType::objectValue);
   value[json_keys::kParams][message_params::kDevice][json_keys::kId] = 1;
+  value[json_keys::kParams][message_params::kDevice][message_params::kName] = "1";
   Json::FastWriter writer;
   std::string json_str = writer.write(value);
 
@@ -343,6 +344,7 @@ TEST_F(CanModuleTest, ChangeDriverDeviceOnOther) {
   value[json_keys::kParams] = Json::Value(Json::ValueType::objectValue);
   value[json_keys::kParams][message_params::kDevice] = Json::Value(Json::ValueType::objectValue);
   value[json_keys::kParams][message_params::kDevice][json_keys::kId] = 1;
+  value[json_keys::kParams][message_params::kDevice][message_params::kName] = "1";
   Json::FastWriter writer;
   std::string json_str = writer.write(value);
 


### PR DESCRIPTION
REVSDL-1376
RSDL: HMI's RPCs validation rules: doesn't validate when HMI responds OnReverseAppsAllowing notification with "allowed" wrong type
REVSDL-1372
RSDL: HMI's RPCs validation rules: doesn't validate when HMI responds OnSetDriversDevice notification with "name" missing
REVSDL-1387
RSDL: HMI's RPCs validation rules: doesn't validate when HMI responds GetInteriorVehicleDataConsent message with "allowed" wrong type