### PR TITLE
REVSDL-1424: implement requiment to take off remote control

### DIFF
--- a/src/components/application_manager/src/commands/hmi/on_exit_application_notification.cc
+++ b/src/components/application_manager/src/commands/hmi/on_exit_application_notification.cc
@@ -36,6 +36,7 @@
 #include "application_manager/message_helper.h"
 #include "interfaces/MOBILE_API.h"
 #include "interfaces/HMI_API.h"
+#include "application_manager/policies/policy_handler.h"
 
 namespace application_manager {
 
@@ -70,6 +71,10 @@ void OnExitApplicationNotification::Run() {
       break;
     }
   }
+
+#ifdef SDL_REMOTE_CONTROL
+  policy::PolicyHandler::instance()->ResetAccess(app_impl->mobile_app_id());
+#endif  // SDL_REMOTE_CONTROL
 
   ApplicationManagerImpl::instance()->ChangeAppsHMILevel(app_impl->app_id(),
                                                          mobile_apis::HMILevel::HMI_NONE);


### PR DESCRIPTION
**Implemented:**
11. In case the application sends a valid rc-RPC with <interiorZone>, <moduleType> and <params> allowed by app's assigned policies
- and "equipment" section of policies database contains this RPC name with <params> in <moduleType> in "driver_allow" sub-section of <interiorZone> section
- and the vehicle (HMI) responds with "allowed: true" for RSDL's RC.GetInteriorVehicleDataConsent
- and RSDL has processed this (app's initial) RPC
- and RSDL gets BC.OnExitApplication (USER_EXIT) for this application from HMI
- RSDL must take off the driver's permissions from this application