### PR TITLE
REVSDL-1435: remove check if resource is already taken according to R…

### DIFF
--- a/src/components/policy/src/policy/src/access_remote_impl.cc
+++ b/src/components/policy/src/policy/src/access_remote_impl.cc
@@ -168,18 +168,8 @@ TypeAccess AccessRemoteImpl::Check(const Subject& who,
           logger_,
           "Subject " << who << " has permissions " << ret << " to object " << what);
     } else {
-      // Look for somebody is who controls this object
-      j = std::find_if(row.begin(), row.end(),
-                       IsTypeAccess(TypeAccess::kAllowed));
-      if (j != row.end()) {
-        // Someone controls this object
-        LOG4CXX_TRACE(logger_, "Someone controls " << what);
-        ret = TypeAccess::kDisallowed;
-      } else {
-        // Nobody controls this object
-        LOG4CXX_TRACE(logger_, "Nobody controls " << what);
-        ret = TypeAccess::kManual;
-      }
+      LOG4CXX_TRACE(logger_, who << " needs driver permission for " << what);
+      ret = TypeAccess::kManual;
     }
   } else {
     // Nobody controls this object

--- a/src/components/policy/test/access_remote_impl_test.cc
+++ b/src/components/policy/test/access_remote_impl_test.cc
@@ -131,7 +131,7 @@ TEST(AccessRemoteImplTest, CheckDisallowed) {
   Object what = { policy_table::MT_RADIO };
 
   access_remote.Allow(who, what);
-  EXPECT_EQ(TypeAccess::kDisallowed, access_remote.Check(who1, what));
+  EXPECT_EQ(TypeAccess::kManual, access_remote.Check(who1, what));
 
   access_remote.Reset(who);
   access_remote.Deny(who1, what);


### PR DESCRIPTION
RSDL doesn't send RC.GetInteriorVehicleDataConsent when sending RPC from another application with the same zone and same moduleType