### PR TITLE
REVSDL-1230

### DIFF
--- a/src/components/can_cooperation/include/can_cooperation/message_helper.h
+++ b/src/components/can_cooperation/include/can_cooperation/message_helper.h
@@ -84,6 +84,16 @@ class MessageHelper {
   static const std::map<functional_modules::MobileFunctionID, std::string> kMobileAPINames;
 };
 
+/**
+ * @brief Check for existence of specified key in Json::Value
+ *
+ * @param value Value with json
+ * @param key string with key name
+ *
+ * @return true if key exist
+ */
+bool IsMember(const Json::Value& value, const std::string& key);
+
 }  // namespace can_cooperation
 
 #endif  // SRC_COMPONENTS_CAN_COOPERATION_INCLUDE_CAN_COOPERATION_MESSAGE_HELPER_H_

--- a/src/components/can_cooperation/src/command/base_command_request.cc
+++ b/src/components/can_cooperation/src/command/base_command_request.cc
@@ -280,16 +280,16 @@ bool BaseCommandRequest::ParseResultCode(const Json::Value& value,
   result_code = result_codes::kInvalidData;
   info = "";
 
-  if (value.isMember(kResult) && value[kResult].isMember(kCode)) {
+  if (IsMember(value, kResult) && IsMember(value[kResult], kCode)) {
     result_code = GetMobileResultCode(
                     static_cast<hmi_apis::Common_Result::eType>(
                       value[kResult][kCode].asInt()));
-  } else if (value.isMember(kError) && value[kError].isMember(kCode)) {
+  } else if (IsMember(value, kError) && IsMember(value[kError], kCode)) {
     result_code = GetMobileResultCode(
                     static_cast<hmi_apis::Common_Result::eType>(
                       value[kError][kCode].asInt()));
 
-    if (value[kError].isMember(kMessage)) {
+    if (IsMember(value[kError], kMessage)) {
       info = value[kError][kMessage].asCString();
     }
   }
@@ -426,8 +426,8 @@ void BaseCommandRequest::ProcessAccessResponse(
   bool allowed = ParseResultCode(value, result_code, info);
   // Check if valid successfull message has arrived
   if (allowed) {
-    if (value[kResult].isMember(message_params::kAllowed)
-         && value[kResult][message_params::kAllowed].isBool()) {
+    if (IsMember(value[kResult], message_params::kAllowed)
+        && value[kResult][message_params::kAllowed].isBool()) {
       allowed = value[kResult][message_params::kAllowed].asBool();
     } else {
       allowed = false;

--- a/src/components/can_cooperation/src/command/get_interior_vehicle_data_capabilities_request.cc
+++ b/src/components/can_cooperation/src/command/get_interior_vehicle_data_capabilities_request.cc
@@ -95,7 +95,7 @@ void GetInteriorVehicleDataCapabiliesRequest::OnEvent(
     const int capabilities_max_size = 1000;
 
     if (success) {
-      if (value[kResult].isMember(kInteriorVehicleDataCapabilities)) {
+      if (IsMember(value[kResult], kInteriorVehicleDataCapabilities)) {
         int capabilities_size =
             value[kResult][kInteriorVehicleDataCapabilities].size();
         if (value[kResult][kInteriorVehicleDataCapabilities].isArray() &&
@@ -152,7 +152,7 @@ bool GetInteriorVehicleDataCapabiliesRequest::ReadCapabilitiesFromFile() {
 
   VehicleCapabilities file_caps;
   Json::Value zone_capabilities;
-  if (request.isMember(kZone)) {
+  if (IsMember(request, kZone)) {
     zone_capabilities = file_caps.capabilities(request[kZone]);
   } else {
     zone_capabilities = file_caps.capabilities();
@@ -161,7 +161,7 @@ bool GetInteriorVehicleDataCapabiliesRequest::ReadCapabilitiesFromFile() {
   if (zone_capabilities.type() == Json::ValueType::arrayValue) {
     LOG4CXX_DEBUG(logger_, "Read vehicle capabilities from file "
         << zone_capabilities);
-    if (request.isMember(kModuleTypes)) {
+    if (IsMember(request, kModuleTypes)) {
       response_params_[kInteriorVehicleDataCapabilities] = Json::Value(
         Json::ValueType::arrayValue);
       for (unsigned int i = 0; i < zone_capabilities.size(); ++i) {

--- a/src/components/can_cooperation/src/command/get_interior_vehicle_data_request.cc
+++ b/src/components/can_cooperation/src/command/get_interior_vehicle_data_request.cc
@@ -64,7 +64,7 @@ void GetInteriorVehicleDataRequest::Execute() {
   Json::Reader reader;
   reader.parse(message_->json_message(), params);
 
-  if (params.isMember(kSubscribe)){
+  if (IsMember(params, kSubscribe)){
     application_manager::ApplicationSharedPtr app =
         service_->GetApplication(message_->connection_key());
 
@@ -108,7 +108,7 @@ void GetInteriorVehicleDataRequest::OnEvent(
     validators::ValidationResult validation_result = validators::SUCCESS;
 
     if (success) {
-      if (value[kResult].isMember(kModuleData)) {
+      if (IsMember(value[kResult], kModuleData)) {
         validation_result =
             validators::ModuleDataValidator::instance()->Validate(
                                               value[kResult][kModuleData],

--- a/src/components/can_cooperation/src/command/set_interior_vehicle_data_request.cc
+++ b/src/components/can_cooperation/src/command/set_interior_vehicle_data_request.cc
@@ -87,7 +87,7 @@ void SetInteriorVehicleDataRequest::OnEvent(
     validators::ValidationResult validation_result = validators::SUCCESS;
 
     if (success) {
-      if (value[kResult].isMember(kModuleData)) {
+      if (IsMember(value[kResult], kModuleData)) {
         validation_result =
             validators::ModuleDataValidator::instance()->Validate(
                                               value[kResult][kModuleData],

--- a/src/components/can_cooperation/src/message_helper.cc
+++ b/src/components/can_cooperation/src/message_helper.cc
@@ -92,4 +92,12 @@ Json::Value MessageHelper::StringToValue(const std::string& string) {
   return Json::Value(Json::ValueType::nullValue);
 }
 
+bool IsMember(const Json::Value& value, const std::string& key) {
+  if (!value.isObject()) {
+    return false;
+  }
+
+  return value.isMember(key);
+}
+
 }  // namespace can_cooperation

--- a/src/components/can_cooperation/src/module_helper.cc
+++ b/src/components/can_cooperation/src/module_helper.cc
@@ -36,6 +36,7 @@
 #include "can_cooperation/can_app_extension.h"
 #include "application_manager/message.h"
 #include "interfaces/HMI_API.h"
+#include "can_cooperation/message_helper.h"
 
 namespace can_cooperation {
 
@@ -77,8 +78,8 @@ application_manager::MessagePtr ResponseToHMI(unsigned int id,
 
 ProcessResult ProcessOnAppDeactivation(
   const Json::Value& value) {
-  if (value.isMember(json_keys::kParams)
-      && value[json_keys::kParams].isMember(message_params::kHMIAppID)) {
+  if (IsMember(value, json_keys::kParams)
+      && IsMember(value[json_keys::kParams], message_params::kHMIAppID)) {
     uint32_t hmi_app_id =
       value[json_keys::kParams][message_params::kHMIAppID].asUInt();
     typedef std::vector<application_manager::ApplicationSharedPtr> AppList;
@@ -111,8 +112,8 @@ ProcessResult ProcessOnAppDeactivation(
 
 functional_modules::ProcessResult ProcessSDLActivateApp(
   const Json::Value& value) {
-  if (value.isMember(json_keys::kParams)
-      && value[json_keys::kParams].isMember(message_params::kHMIAppID)) {
+  if (IsMember(value, json_keys::kParams)
+      && IsMember(value[json_keys::kParams], message_params::kHMIAppID)) {
     uint32_t hmi_app_id =
       value[json_keys::kParams][message_params::kHMIAppID].asUInt();
     typedef std::vector<application_manager::ApplicationSharedPtr> AppList;

--- a/src/components/can_cooperation/src/validators/button_press_request_validator.cc
+++ b/src/components/can_cooperation/src/validators/button_press_request_validator.cc
@@ -33,6 +33,7 @@
 #include "can_cooperation/validators/button_press_request_validator.h"
 #include "can_cooperation/validators/struct_validators/interior_zone_validator.h"
 #include "can_cooperation/can_module_constants.h"
+#include "can_cooperation/message_helper.h"
 
 namespace can_cooperation {
 
@@ -77,7 +78,7 @@ ValidationResult ButtonPressRequestValidator::Validate(const Json::Value& json,
     return result;
   }
 
-  if (json.isMember(kZone)) {
+  if (IsMember(json, kZone)) {
     result = InteriorZoneValidator::instance()->Validate(json[kZone],
                                                          outgoing_json[kZone]);
   } else {

--- a/src/components/can_cooperation/src/validators/get_interior_vehicle_data_capabilities_request_validator.cc
+++ b/src/components/can_cooperation/src/validators/get_interior_vehicle_data_capabilities_request_validator.cc
@@ -33,6 +33,7 @@
 #include "can_cooperation/validators/get_interior_vehicle_data_capabilities_request_validator.h"
 #include "can_cooperation/validators/struct_validators/interior_zone_validator.h"
 #include "can_cooperation/can_module_constants.h"
+#include "can_cooperation/message_helper.h"
 
 namespace can_cooperation {
 
@@ -66,7 +67,7 @@ ValidationResult GetInteriorVehicleDataCapabilitiesRequestValidator::Validate(
     return result;
   }
 
-  if (json.isMember(kZone)) {
+  if (IsMember(json, kZone)) {
     result = InteriorZoneValidator::instance()->Validate(json[kZone],
                                                     outgoing_json[kZone]);
   }

--- a/src/components/can_cooperation/src/validators/get_interior_vehicle_data_request_validator.cc
+++ b/src/components/can_cooperation/src/validators/get_interior_vehicle_data_request_validator.cc
@@ -33,6 +33,7 @@
 #include "can_cooperation/validators/get_interior_vehicle_data_request_validator.h"
 #include "can_cooperation/validators/struct_validators/module_description_validator.h"
 #include "can_cooperation/can_module_constants.h"
+#include "can_cooperation/message_helper.h"
 
 namespace can_cooperation {
 
@@ -63,7 +64,7 @@ ValidationResult GetInteriorVehicleDataRequestValidator::Validate(
     return result;
   }
 
-  if (json.isMember(kModuleDescription)) {
+  if (IsMember(json, kModuleDescription)) {
     result = ModuleDescriptionValidator::instance()->
         Validate(json[kModuleDescription], outgoing_json[kModuleDescription]);
   } else {

--- a/src/components/can_cooperation/src/validators/on_interior_vehicle_data_notification_validator.cc
+++ b/src/components/can_cooperation/src/validators/on_interior_vehicle_data_notification_validator.cc
@@ -56,7 +56,7 @@ ValidationResult OnInteriorVehicleDataNotificationValidator::Validate(
 
   ValidationResult result;
 
-  if (json.isMember(kModuleData)) {
+  if (IsMember(json, kModuleData)) {
     result = ModuleDataValidator::instance()->
         Validate(json[kModuleData], outgoing_json[kModuleData]);
   } else {

--- a/src/components/can_cooperation/src/validators/set_interior_vehicle_data_request_validator.cc
+++ b/src/components/can_cooperation/src/validators/set_interior_vehicle_data_request_validator.cc
@@ -33,6 +33,7 @@
 #include "can_cooperation/validators/set_interior_vehicle_data_request_validator.h"
 #include "can_cooperation/validators/struct_validators/module_data_validator.h"
 #include "can_cooperation/can_module_constants.h"
+#include "can_cooperation/message_helper.h"
 
 namespace can_cooperation {
 
@@ -53,7 +54,7 @@ ValidationResult SetInteriorVehicleDataRequestValidator::Validate(
 
   ValidationResult result;
 
-  if (json.isMember(kModuleData)) {
+  if (IsMember(json, kModuleData)) {
     result = ModuleDataValidator::instance()->
         Validate(json[kModuleData], outgoing_json[kModuleData]);
   } else {

--- a/src/components/can_cooperation/src/validators/struct_validators/module_data_validator.cc
+++ b/src/components/can_cooperation/src/validators/struct_validators/module_data_validator.cc
@@ -35,6 +35,7 @@
 #include "can_cooperation/validators/struct_validators/radio_control_data_validator.h"
 #include "can_cooperation/validators/struct_validators/climate_control_data_validator.h"
 #include "can_cooperation/can_module_constants.h"
+#include "can_cooperation/message_helper.h"
 
 namespace can_cooperation {
 
@@ -65,7 +66,7 @@ ValidationResult ModuleDataValidator::Validate(const Json::Value& json,
     return result;
   }
 
-  if (json.isMember(kModuleZone)) {
+  if (IsMember(json, kModuleZone)) {
     result = InteriorZoneValidator::instance()->Validate(json[kModuleZone],
                                                     outgoing_json[kModuleZone]);
   } else {
@@ -77,7 +78,7 @@ ValidationResult ModuleDataValidator::Validate(const Json::Value& json,
     return result;
   }
 
-  if (json.isMember(kRadioControlData)) {
+  if (IsMember(json, kRadioControlData)) {
     result = RadioControlDataValidator::instance()->Validate(
                                               json[kRadioControlData],
                                               outgoing_json[kRadioControlData]);
@@ -92,7 +93,7 @@ ValidationResult ModuleDataValidator::Validate(const Json::Value& json,
     return result;
   }
 
-  if (json.isMember(kClimateControlData)) {
+  if (IsMember(json, kClimateControlData)) {
     result = ClimateControlDataValidator::instance()->Validate(
                                              json[kClimateControlData],
                                              outgoing_json[kClimateControlData]);

--- a/src/components/can_cooperation/src/validators/struct_validators/module_description_validator.cc
+++ b/src/components/can_cooperation/src/validators/struct_validators/module_description_validator.cc
@@ -32,6 +32,7 @@
 
 #include "can_cooperation/validators/struct_validators/module_description_validator.h"
 #include "can_cooperation/validators/struct_validators/interior_zone_validator.h"
+#include "can_cooperation/message_helper.h"
 #include "can_cooperation/can_module_constants.h"
 
 namespace can_cooperation {
@@ -63,7 +64,7 @@ ValidationResult ModuleDescriptionValidator::Validate(const Json::Value& json,
     return result;
   }
 
-  if (json.isMember(kModuleZone)) {
+  if (IsMember(json, kModuleZone)) {
     result = InteriorZoneValidator::instance()->Validate(json[kModuleZone],
                                                     outgoing_json[kModuleZone]);
   } else {

--- a/src/components/can_cooperation/src/validators/struct_validators/radio_control_data_validator.cc
+++ b/src/components/can_cooperation/src/validators/struct_validators/radio_control_data_validator.cc
@@ -32,6 +32,7 @@
 
 #include "can_cooperation/validators/struct_validators/radio_control_data_validator.h"
 #include "can_cooperation/validators/struct_validators/rds_data_validator.h"
+#include "can_cooperation/message_helper.h"
 #include "can_cooperation/can_module_constants.h"
 
 namespace can_cooperation {
@@ -123,7 +124,7 @@ ValidationResult RadioControlDataValidator::Validate(const Json::Value& json,
     return result;
   }
 
-  if (json.isMember(kRdsData)) {
+  if (IsMember(json, kRdsData)) {
     result = RdsDataValidator::instance()->Validate(json[kRdsData],
                                                     outgoing_json[kRdsData]);
   }

--- a/src/components/can_cooperation/src/validators/validator.cc
+++ b/src/components/can_cooperation/src/validators/validator.cc
@@ -32,6 +32,7 @@
 
 #include "can_cooperation/validators/validator.h"
 #include "can_cooperation/can_module_constants.h"
+#include "can_cooperation/message_helper.h"
 #include "utils/logger.h"
 
 namespace can_cooperation {
@@ -70,7 +71,7 @@ ValidationResult Validator::ValidateValue(const std::string& value_name,
                                  Json::Value& outgoing_json,
                                  ValidationScope& validation_scope) {
   // Check if param exist, and its mandatory
-  if (!json.isMember(value_name)) {
+  if (!IsMember(json, value_name)) {
     if (validation_scope[ValidationParams::MANDATORY]) {
       LOG4CXX_ERROR(logger_, "Mandatory param " <<value_name <<" missing!" );
       return ValidationResult::INVALID_DATA;

--- a/src/components/functional_module/src/plugin_manager.cc
+++ b/src/components/functional_module/src/plugin_manager.cc
@@ -184,6 +184,7 @@ ProcessResult PluginManager::ProcessHMIMessage(application_manager::MessagePtr m
       function_name = value["error"]["data"]["method"].asCString();
     } else {
       DCHECK(false);
+      return ProcessResult::CANNOT_PROCESS;
     }
   }
 


### PR DESCRIPTION
SDL: App's RPCs validation rules: Core dump when sending "ButtonPress" RPC with "zone" wrong type
REVSDL-1365
RSDL: HMI's RPCs validation rules: Core dump when HMI responds "SetInteriorVehicleData" with moduleData of wrong type