### PR TITLE
REVSDL-1576: fix for limited hmiLevel for passenger's device during r…

### DIFF
--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -607,10 +607,6 @@ mobile_api::HMILevel::eType ApplicationManagerImpl::IsHmiLevelFullAllowed(
   } else if (is_active_app_exist && (!is_audio_app)) {
     result = GetDefaultHmiLevel(app);
   }
-  if (!functional_modules::PluginManager::instance()->CanAppChangeHMILevel(app,
-    mobile_apis::HMILevel::HMI_FULL)) {
-    result = GetDefaultHmiLevel(app);
-  }
 
   LOG4CXX_ERROR(logger_, "is_audio_app : " << is_audio_app
                 << "; does_audio_app_with_same_type_exist : " << does_audio_app_with_same_type_exist

--- a/src/components/application_manager/src/resume_ctrl.cpp
+++ b/src/components/application_manager/src/resume_ctrl.cpp
@@ -47,6 +47,7 @@
 #include "resumption/last_state.h"
 #include "policy/policy_manager_impl.h"
 #include "application_manager/policies/policy_handler.h"
+#include "functional_module/plugin_manager.h"
 
 namespace application_manager {
 
@@ -222,6 +223,12 @@ bool ResumeCtrl::SetAppHMIState(ApplicationSharedPtr application,
       restored_hmi_level =
           ApplicationManagerImpl::instance()->GetDefaultHmiLevel(application);
     }
+  }
+  if (!functional_modules::PluginManager::instance()->CanAppChangeHMILevel(
+      application,
+      restored_hmi_level)) {
+    restored_hmi_level =
+        ApplicationManagerImpl::instance()->GetDefaultHmiLevel(application);
   }
 
   const AudioStreamingState::eType restored_audio_state =

--- a/src/components/can_cooperation/src/can_module.cc
+++ b/src/components/can_cooperation/src/can_module.cc
@@ -400,7 +400,8 @@ bool CANModule::CanAppChangeHMILevel(
   CANAppExtensionPtr can_app_extension =
     application_manager::AppExtensionPtr::static_pointer_cast<CANAppExtension>(
       app_extension);
-  if (new_level == mobile_apis::HMILevel::eType::HMI_FULL) {
+  if (new_level == mobile_apis::HMILevel::eType::HMI_FULL ||
+      new_level == mobile_apis::HMILevel::eType::HMI_LIMITED) {
     return can_app_extension->is_on_driver_device();
   }
   return true;


### PR DESCRIPTION
The mechanism of rc-apps resumption was not discussed yet.
Per current requirements, the above expected result is correct: remote-control applications must get NONE level when they register from a passenger's device.