### PR TITLE
REVSDL-1749

### DIFF
--- a/src/components/can_cooperation/CMakeLists.txt
+++ b/src/components/can_cooperation/CMakeLists.txt
@@ -77,6 +77,7 @@ set (SOURCES
     ./src/validators/button_press_request_validator.cc
     ./src/validators/get_interior_vehicle_data_capabilities_request_validator.cc
     ./src/validators/get_interior_vehicle_data_request_validator.cc
+    ./src/validators/get_interior_vehicle_data_response_validator.cc
     ./src/validators/set_interior_vehicle_data_request_validator.cc
     ./src/validators/on_interior_vehicle_data_notification_validator.cc
     ./src/policy_helper.cc

--- a/src/components/can_cooperation/include/can_cooperation/can_app_extension.h
+++ b/src/components/can_cooperation/include/can_cooperation/can_app_extension.h
@@ -37,11 +37,15 @@
 #include <set>
 #include "application_manager/service.h"
 #include "application_manager/app_extension.h"
+#include "can_cooperation/can_module.h"
 #include "json/json.h"
 
 using application_manager::SeatLocation;
 
+
+
 namespace can_cooperation {
+
 class CANAppExtension : public application_manager::AppExtension {
   public:
     explicit CANAppExtension(application_manager::AppExtensionUID uid);
@@ -94,6 +98,9 @@ class CANAppExtension : public application_manager::AppExtension {
      */
     bool IsSubscibedToInteriorVehicleData(const Json::Value& moduleDescription);
 
+    friend void CANModule::UnsubscribeAppForAllZones(uint32_t hmi_app_id,
+                                                     CANAppExtensionPtr app);
+
   private:
     bool is_control_given_;
     SeatLocation seat_;
@@ -103,6 +110,7 @@ class CANAppExtension : public application_manager::AppExtension {
 };
 
 typedef utils::SharedPtr<CANAppExtension> CANAppExtensionPtr;
+
 }  //  namespace can_cooperation
 
 #endif  //  SRC_COMPONENTS_CAN_COOPERATION_INCLUDE_CAN_COOPERATION_CAN_APP_EXTENSION_H_

--- a/src/components/can_cooperation/include/can_cooperation/can_module.h
+++ b/src/components/can_cooperation/include/can_cooperation/can_module.h
@@ -42,6 +42,10 @@
 
 
 namespace can_cooperation {
+
+class CANAppExtension;
+typedef utils::SharedPtr<CANAppExtension> CANAppExtensionPtr;
+
 struct MessageFromCAN : public Json::Value {
   explicit MessageFromCAN(const Json::Value& other): Json::Value(other) {}
 };
@@ -130,10 +134,10 @@ class CANModule : public functional_modules::GenericModule,
    */
   void OnDeviceRemoved(const connection_handler::DeviceHandle& device);
 
-  void SendHmiStatusNotifications(const uint32_t device_handle,
-                                  const std::string& rank);
-
   void SendHmiStatusNotification(application_manager::ApplicationSharedPtr app);
+
+  void UnsubscribeAppForAllZones(uint32_t hmi_app_id,
+                                 CANAppExtensionPtr app);
 
  protected:
   /**

--- a/src/components/can_cooperation/include/can_cooperation/can_module_constants.h
+++ b/src/components/can_cooperation/include/can_cooperation/can_module_constants.h
@@ -172,6 +172,7 @@ const char kSubscribe[]         = "subscribe";
 
 // GetInteriorVehicleData response
 //const char kModuleData[] = "moduleData";
+const char kIsSubscribed[] = "isSubscribed";
 // GetInteriorVehicleData response
 
 // OnInteriorVehicleData notification

--- a/src/components/can_cooperation/include/can_cooperation/module_helper.h
+++ b/src/components/can_cooperation/include/can_cooperation/module_helper.h
@@ -35,26 +35,48 @@
 
 #include "functional_module/generic_module.h"
 #include "json/json.h"
+#include "interfaces/HMI_API.h"
 
 namespace can_cooperation {
 
-/*
- * @brief Checks if deactivated app was of R-SDL type
- * and process correspondingly. Otherwise returns
- * CANNOT_PROCESS.
- * @param value Json notification from HMI
- */
-functional_modules::ProcessResult ProcessOnAppDeactivation(
-  const Json::Value& value);
+/**
+ * @brief ModuleHelper class
+ **/
+class ModuleHelper {
+ public:
 
-/*
- * @brief Check if activated/other apps are of R-SDL type;
- * process correspondingly.
- * If no R-SDL app is involved returns CANNOT_PROCESS.
- * @param value Json request from HMI
- */
-functional_modules::ProcessResult ProcessSDLActivateApp(
-  const Json::Value& value);
+  /*
+   * @brief Checks if deactivated app was of R-SDL type
+   * and process correspondingly. Otherwise returns
+   * CANNOT_PROCESS.
+   * @param value Json notification from HMI
+   */
+   static functional_modules::ProcessResult ProcessOnAppDeactivation(
+    const Json::Value& value);
+
+  /*
+   * @brief Check if activated/other apps are of R-SDL type;
+   * process correspondingly.
+   * If no R-SDL app is involved returns CANNOT_PROCESS.
+   * @param value Json request from HMI
+   */
+  static functional_modules::ProcessResult ProcessSDLActivateApp(
+    const Json::Value& value);
+
+  static void ProccessDeviceRankChanged(const uint32_t device_handle,
+                            const std::string& rank);
+
+  static void ProccessOnReverseAppsDisallowed ();
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(ModuleHelper);
+
+  ModuleHelper();
+
+  static application_manager::MessagePtr ResponseToHMI(unsigned int id,
+                                     hmi_apis::Common_Result::eType result_code,
+                                     const std::string& method_name);
+};
 
 }  //  namespace can_cooperation
 

--- a/src/components/can_cooperation/include/can_cooperation/validators/get_interior_vehicle_data_response_validator.h
+++ b/src/components/can_cooperation/include/can_cooperation/validators/get_interior_vehicle_data_response_validator.h
@@ -30,61 +30,45 @@
  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef SRC_COMPONENTS_CAN_COOPERATION_INCLUDE_CAN_COOPERATION_COMMANDS_GET_INTERIOR_VEHICLE_DATA_REQUEST_H_
-#define SRC_COMPONENTS_CAN_COOPERATION_INCLUDE_CAN_COOPERATION_COMMANDS_GET_INTERIOR_VEHICLE_DATA_REQUEST_H_
+#ifndef SRC_COMPONENTS_CAN_COOPERATION_INCLUDE_CAN_COOPERATION_VALIDATORS_GET_INTERIOR_VEHICLE_DATA_RESPONSE_VALIDATOR_H_
+#define SRC_COMPONENTS_CAN_COOPERATION_INCLUDE_CAN_COOPERATION_VALIDATORS_GET_INTERIOR_VEHICLE_DATA_RESPONSE_VALIDATOR_H_
 
-#include "can_cooperation/commands/base_command_request.h"
-#include "can_cooperation/event_engine/event.h"
+#include "can_cooperation/validators/validator.h"
+#include "utils/singleton.h"
 
 namespace can_cooperation {
 
-namespace commands {
+namespace validators {
 
 /**
- * @brief GetInteriorVehicleDataRequest command class
+ * @brief GetInteriorVehicleDataResponseValidator class
  */
-class GetInteriorVehicleDataRequest : public BaseCommandRequest {
+class GetInteriorVehicleDataResponseValidator : public Validator,
+   public utils::Singleton<GetInteriorVehicleDataResponseValidator> {
  public:
+
   /**
-   * @brief GetInteriorVehicleDataRequest class constructor
+   * @brief Validate json with message params
    *
-   * @param message Message from mobile
-   **/
-  explicit GetInteriorVehicleDataRequest(const application_manager::MessagePtr& message);
-
-  /**
-   * @brief Execute command
-   */
-  virtual void Execute();
-
-  /**
-   * @brief executes specific message validation
-   */
-  virtual bool Validate();
-
-  /**
-   * @brief Interface method that is called whenever new event received
+   * @param json_string string with message params(fake params will be cut off)
+   * @param outgoing_json outgoing json
    *
-   * @param event The received event
+   * @return validation result
    */
-  void OnEvent(const event_engine::Event<application_manager::MessagePtr,
-                std::string>& event);
-
- protected:
-  virtual std::string ModuleType(const Json::Value& message);
-  virtual Json::Value GetInteriorZone(const Json::Value& message);
-  virtual SeatLocation InteriorZone(const Json::Value& message);
+  ValidationResult Validate(const Json::Value& json,
+                            Json::Value& outgoing_json);
 
  private:
-  /**
-    * @brief Handle subscription to vehicle data
-    *
-    */
-  void ProccessSubscription();
+  DISALLOW_COPY_AND_ASSIGN(GetInteriorVehicleDataResponseValidator);
+  FRIEND_BASE_SINGLETON_CLASS(GetInteriorVehicleDataResponseValidator);
+  GetInteriorVehicleDataResponseValidator();
+  ~GetInteriorVehicleDataResponseValidator() {};
+
+  ValidationScope is_subscribed_;
 };
 
-}  // namespace commands
+}  // namespace valdiators
 
 }  // namespace can_cooperation
 
-#endif  // SRC_COMPONENTS_CAN_COOPERATION_INCLUDE_CAN_COOPERATION_COMMANDS_GET_INTERIOR_VEHICLE_DATA_REQUEST_H_
+#endif  // SRC_COMPONENTS_CAN_COOPERATION_INCLUDE_CAN_COOPERATION_VALIDATORS_GET_INTERIOR_VEHICLE_DATA_RESPONSE_VALIDATOR_H_

--- a/src/components/can_cooperation/src/command/base_command_request.cc
+++ b/src/components/can_cooperation/src/command/base_command_request.cc
@@ -111,6 +111,8 @@ void  BaseCommandRequest::SendRequest(const char* function_id,
     msg[kParams] = message_params;
   }
 
+  msg[kParams][json_keys::kAppId] = app_->hmi_app_id();
+
   Json::FastWriter writer;
   if (is_hmi_request) {
     application_manager::MessagePtr message_to_send(
@@ -307,7 +309,7 @@ void BaseCommandRequest::Run() {
   if (Validate()) {
     LOG4CXX_INFO(logger_, "Request message validated successfully!");
     if (CheckPolicy()) {
-       Execute();  // run child's logic
+      Execute();  // run child's logic
     }
   }
 }


### PR DESCRIPTION
Subscriptions: reset upon device rank change and RC disabling
REVSDL-1678
GetInteriorVehicleData - new param in response and RSDL's subscription behavior
REVSDL-1766
HMI_API: appID must be added to all RC-related requests