### PR TITLE
Fix/revsdl 1873 get interior vehicle data consent

### DIFF
--- a/src/components/application_manager/include/application_manager/core_service.h
+++ b/src/components/application_manager/include/application_manager/core_service.h
@@ -145,6 +145,13 @@ class CoreService : public Service {
   void SetDeviceZone(const uint32_t dev_id,const SeatLocation& zone);
 
   /**
+   * Gets device zone
+   * @param dev_id ID device
+   * @return device zone is unknown otherwise 0
+   */
+  const SeatLocationPtr GetDeviceZone(const uint32_t dev_id) const;
+
+  /**
    * Sets mode of remote control (on/off)
    * @param enabled true if remote control is turned on
    */

--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -167,6 +167,14 @@ class PolicyHandler :
                      const application_manager::SeatLocation& zone);
 
   /**
+   * Gets device zone
+   * @param dev_id ID device
+   * @return device zone is unknown otherwise 0
+   */
+  const application_manager::SeatLocationPtr GetDeviceZone(
+      const std::string& device_id) const;
+
+  /**
    * Sets mode of remote control (on/off)
    * @param enabled true if remote control is turned on
    */

--- a/src/components/application_manager/include/application_manager/service.h
+++ b/src/components/application_manager/include/application_manager/service.h
@@ -51,6 +51,7 @@ enum TypeAccess {
 struct SeatLocation {
   int col, row, level;
 };
+typedef utils::SharedPtr<SeatLocation> SeatLocationPtr;
 
 typedef std::string PluginFunctionID;
 /**
@@ -143,6 +144,13 @@ class Service {
    */
   virtual void SetDeviceZone(const uint32_t dev_id,
                              const SeatLocation& zone) = 0;
+
+  /**
+   * Gets device zone
+   * @param dev_id ID device
+   * @return device zone is unknown otherwise 0
+   */
+  virtual const SeatLocationPtr GetDeviceZone(const uint32_t dev_id) const = 0;
 
   /**
    * Sets mode of remote control (on/off)

--- a/src/components/application_manager/src/core_service.cc
+++ b/src/components/application_manager/src/core_service.cc
@@ -167,6 +167,15 @@ void CoreService::SetDeviceZone(const uint32_t dev_id,
 #endif  // SDL_REMOTE_CONTROL
 }
 
+const SeatLocationPtr CoreService::GetDeviceZone(const uint32_t dev_id) const {
+#ifdef SDL_REMOTE_CONTROL
+  std::string device_handle = MessageHelper::GetDeviceMacAddressForHandle(
+      dev_id);
+  return policy::PolicyHandler::instance()->GetDeviceZone(device_handle);
+#endif  // SDL_REMOTE_CONTROL
+  return 0;
+}
+
 void CoreService::SetRemoteControl(bool enabled) {
 #ifdef SDL_REMOTE_CONTROL
   policy::PolicyHandler::instance()->SetRemoteControl(enabled);

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -1501,6 +1501,21 @@ void PolicyHandler::SetDeviceZone(const std::string& device_id,
   }
 }
 
+const application_manager::SeatLocationPtr PolicyHandler::GetDeviceZone(
+    const std::string& device_id) const {
+  POLICY_LIB_CHECK(0);
+  policy::SeatLocation policy_zone;
+  if (policy_manager_->GetDeviceZone(device_id, &policy_zone)) {
+    application_manager::SeatLocationPtr zone =
+        new application_manager::SeatLocation();
+    zone->col = policy_zone.col;
+    zone->row = policy_zone.row;
+    zone->level = policy_zone.level;
+    return zone;
+  }
+  return 0;
+}
+
 void PolicyHandler::SetRemoteControl(bool enabled) {
   POLICY_LIB_CHECK_VOID();
   policy_manager_->SetRemoteControl(enabled);

--- a/src/components/can_cooperation/include/can_cooperation/can_app_extension.h
+++ b/src/components/can_cooperation/include/can_cooperation/can_app_extension.h
@@ -40,9 +40,7 @@
 #include "can_cooperation/can_module.h"
 #include "json/json.h"
 
-using application_manager::SeatLocation;
-
-
+using application_manager::SeatLocationPtr;
 
 namespace can_cooperation {
 
@@ -63,11 +61,11 @@ class CANAppExtension : public application_manager::AppExtension {
      */
     void GiveControl(bool is_control_given);
 
-    void set_seat(const SeatLocation& seat) {
+    void set_seat(const SeatLocationPtr seat) {
       seat_ = seat;
     }
 
-    const SeatLocation& seat() const {
+    const SeatLocationPtr seat() const {
       return seat_;
     }
 
@@ -103,7 +101,7 @@ class CANAppExtension : public application_manager::AppExtension {
 
   private:
     bool is_control_given_;
-    SeatLocation seat_;
+    SeatLocationPtr seat_;
     bool is_on_driver_device_;
     std::set<Json::Value> subscribed_interior_vehicle_data_;
 

--- a/src/components/can_cooperation/include/can_cooperation/can_module.h
+++ b/src/components/can_cooperation/include/can_cooperation/can_module.h
@@ -40,7 +40,6 @@
 #include "can_cooperation/request_controller.h"
 #include "utils/threads/message_loop_thread.h"
 
-
 namespace can_cooperation {
 
 class CANAppExtension;

--- a/src/components/can_cooperation/include/can_cooperation/commands/base_command_notification.h
+++ b/src/components/can_cooperation/include/can_cooperation/commands/base_command_notification.h
@@ -43,6 +43,8 @@ namespace Json {
 class Value;
 }
 
+using application_manager::SeatLocation;
+
 namespace can_cooperation {
 
 namespace commands {

--- a/src/components/can_cooperation/include/can_cooperation/commands/base_command_request.h
+++ b/src/components/can_cooperation/include/can_cooperation/commands/base_command_request.h
@@ -42,6 +42,8 @@
 #include "can_cooperation/can_app_extension.h"
 #include "json/json.h"
 
+using application_manager::SeatLocation;
+
 namespace can_cooperation {
 
 namespace commands {

--- a/src/components/can_cooperation/include/can_cooperation/commands/base_command_request.h
+++ b/src/components/can_cooperation/include/can_cooperation/commands/base_command_request.h
@@ -174,7 +174,10 @@ class BaseCommandRequest : public Command,
   void ProcessAccessResponse(
       const event_engine::Event<application_manager::MessagePtr,
       std::string>& event);
+  SeatLocation GetDeviceLocation(const Json::Value& value);
+  Json::Value JsonDeviceLocation(const Json::Value& value);
   application_manager::ApplicationSharedPtr app_;
+  SeatLocation device_location_;
 };
 
 }  // namespace commands

--- a/src/components/can_cooperation/src/can_app_extension.cc
+++ b/src/components/can_cooperation/src/can_app_extension.cc
@@ -36,7 +36,7 @@ namespace can_cooperation {
 CANAppExtension::CANAppExtension(application_manager::AppExtensionUID uid)
   : AppExtension(uid) ,
     is_control_given_(false),
-    seat_(),
+    seat_(0),
     is_on_driver_device_(false) {
 }
 

--- a/src/components/can_cooperation/src/can_module.cc
+++ b/src/components/can_cooperation/src/can_module.cc
@@ -46,6 +46,7 @@
 
 namespace can_cooperation {
 
+using application_manager::SeatLocation;
 using functional_modules::ProcessResult;
 using functional_modules::GenericModule;
 using functional_modules::PluginInfo;

--- a/src/components/can_cooperation/src/command/base_command_notification.cc
+++ b/src/components/can_cooperation/src/command/base_command_notification.cc
@@ -35,6 +35,8 @@
 #include "can_cooperation/can_module.h"
 #include "can_cooperation/can_module_constants.h"
 
+using application_manager::SeatLocation;
+
 namespace can_cooperation {
 
 namespace commands {

--- a/src/components/can_cooperation/test/include/mock_service.h
+++ b/src/components/can_cooperation/test/include/mock_service.h
@@ -80,6 +80,7 @@ class MockService : public Service {
   MOCK_CONST_METHOD0(IsRemoteControlAllowed, bool());
   MOCK_METHOD2(SetDeviceZone, void(const uint32_t dev_id,
                                    const SeatLocation& zone));
+  MOCK_CONST_METHOD1(GetDeviceZone, const SeatLocationPtr(const uint32_t dev_id));
 };
 
 }

--- a/src/components/functional_module/test/include/mock_service.h
+++ b/src/components/functional_module/test/include/mock_service.h
@@ -80,6 +80,7 @@ class MockService : public Service {
   MOCK_CONST_METHOD0(IsRemoteControlAllowed, bool());
   MOCK_METHOD2(SetDeviceZone, void(const uint32_t dev_id,
                                    const SeatLocation& zone));
+  MOCK_CONST_METHOD1(GetDeviceZone, const SeatLocationPtr(const uint32_t dev_id));
 };
 
 }

--- a/src/components/policy/src/policy/include/policy/access_remote.h
+++ b/src/components/policy/src/policy/include/policy/access_remote.h
@@ -265,11 +265,10 @@ class AccessRemote {
   /**
    * Gets device zone
    * @param device_id unique identifier of device
-   * @param default_zone zone will be used if policy doesn't have zone of this device
-   * @return device zone
+   * @return device zone if device has zone otherwise 0
    */
-  virtual SeatLocation GetDeviceZone(const std::string& device_id,
-                                     SeatLocation default_zone) const = 0;
+  virtual const SeatLocation* GetDeviceZone(
+      const std::string& device_id) const = 0;
 
   /**
    * Sets device zone

--- a/src/components/policy/src/policy/include/policy/access_remote_impl.h
+++ b/src/components/policy/src/policy/include/policy/access_remote_impl.h
@@ -76,9 +76,7 @@ class AccessRemoteImpl : public AccessRemote {
                                     const std::string &app_id,
                                     FunctionalIdType& group_types);
   virtual bool IsAppReverse(const PTString& app_id);
-  virtual SeatLocation GetDeviceZone(
-      const std::string& device_id,
-      const SeatLocation default_zone = { }) const;
+  virtual const SeatLocation* GetDeviceZone(const std::string& device_id) const;
   virtual void SetDeviceZone(const std::string& device_id,
                              const SeatLocation& zone);
 

--- a/src/components/policy/src/policy/include/policy/policy_manager.h
+++ b/src/components/policy/src/policy/include/policy/policy_manager.h
@@ -490,6 +490,15 @@ class PolicyManager : public usage_statistics::StatisticsManager {
                                const SeatLocation& zone) = 0;
 
     /**
+     * Gets device zone
+     * @param dev_id unique identifier of device
+     * @param zone value to return zone if device has zone
+     * @return true if device has zone
+     */
+    virtual bool GetDeviceZone(const PTString& dev_id,
+                               SeatLocation* zone) const = 0;
+
+    /**
      * Sets mode of remote control (on/off)
      * @param enabled true if remote control is turned on
      */

--- a/src/components/policy/src/policy/include/policy/policy_manager_impl.h
+++ b/src/components/policy/src/policy/include/policy/policy_manager_impl.h
@@ -187,6 +187,7 @@ class PolicyManagerImpl : public PolicyManager {
     virtual void ResetPrimaryDevice();
     virtual PTString PrimaryDevice() const;
     virtual void SetDeviceZone(const PTString& dev_id, const SeatLocation& zone);
+    virtual bool GetDeviceZone(const PTString& dev_id, SeatLocation* zone) const;
     virtual void SetRemoteControl(bool enabled);
     virtual bool GetRemoteControl() const;
     virtual void OnChangedPrimaryDevice(const std::string& application_id);

--- a/src/components/policy/src/policy/src/access_remote_impl.cc
+++ b/src/components/policy/src/policy/src/access_remote_impl.cc
@@ -399,13 +399,13 @@ void AccessRemoteImpl::GetGroupsIds(const std::string &device_id,
   LOG4CXX_DEBUG(logger_, "Groups Ids: " << groups_ids);
 }
 
-SeatLocation AccessRemoteImpl::GetDeviceZone(
-    const std::string& device_id, SeatLocation default_zone) const {
+const SeatLocation* AccessRemoteImpl::GetDeviceZone(
+    const std::string& device_id) const {
   SeatList::const_iterator i = seats_.find(device_id);
   if (i != seats_.end()) {
-    return i->second;
+    return &i->second;
   }
-  return default_zone;
+  return 0;
 }
 
 void AccessRemoteImpl::SetDeviceZone(const std::string& device_id,

--- a/src/components/policy/src/policy/src/policy_manager_impl.cc
+++ b/src/components/policy/src/policy/src/policy_manager_impl.cc
@@ -1016,10 +1016,7 @@ TypeAccess PolicyManagerImpl::CheckDriverConsent(
     return TypeAccess::kDisallowed;
   }
 
-  const SeatLocation device_zone = access_remote_->GetDeviceZone(who.dev_id,
-                                                                 what.zone);
-  const Object resource = { what.module, device_zone };
-  TypeAccess access = access_remote_->CheckParameters(resource, rpc, params);
+  TypeAccess access = access_remote_->CheckParameters(what, rpc, params);
   if (access == TypeAccess::kManual) {
     return access_remote_->Check(who, what);
   }
@@ -1089,6 +1086,18 @@ PTString PolicyManagerImpl::PrimaryDevice() const {
 void PolicyManagerImpl::SetDeviceZone(const PTString& dev_id,
                                       const SeatLocation& zone) {
   access_remote_->SetDeviceZone(dev_id, zone);
+}
+
+bool PolicyManagerImpl::GetDeviceZone(const PTString& dev_id,
+                                      SeatLocation* zone) const {
+  const SeatLocation* seat = access_remote_->GetDeviceZone(dev_id);
+  if (seat) {
+    zone->col = seat->col;
+    zone->row = seat->row;
+    zone->level = seat->level;
+    return true;
+  }
+  return false;
 }
 
 void PolicyManagerImpl::SetRemoteControl(bool enabled) {

--- a/src/components/policy/test/access_remote_impl_test.cc
+++ b/src/components/policy/test/access_remote_impl_test.cc
@@ -417,22 +417,15 @@ TEST(AccessRemoteImplTest, CheckParameters) {
 TEST(AccessRemoteImplTest, GetDeviceZone) {
   AccessRemoteImpl access_remote;
 
-  // Default zone
-  SeatLocation expect = {};
-  SeatLocation zone = access_remote.GetDeviceZone("dev_1");
-  EXPECT_EQ(expect, zone);
-
-  // Specific default zone
-  SeatLocation default_zone = { 0, 1, 0 };
-  zone = access_remote.GetDeviceZone("dev_1", default_zone);
-  EXPECT_EQ(default_zone, zone);
+  // No zone
+  const SeatLocation* zone1 = access_remote.GetDeviceZone("dev_1");
+  EXPECT_EQ(0, zone1);
 
   // Device has zone
-  default_zone = { 1, 1, 1 };
-  expect = { 0, 1, 0 };
+  SeatLocation expect = { 0, 1, 0 };
   access_remote.seats_["dev_2"] = expect;
-  zone = access_remote.GetDeviceZone("dev_2", default_zone);
-  EXPECT_EQ(expect, zone);
+  const SeatLocation* zone2 = access_remote.GetDeviceZone("dev_2");
+  EXPECT_EQ(expect, *zone2);
 }
 
 }  // namespace policy

--- a/src/components/policy/test/include/mock_access_remote.h
+++ b/src/components/policy/test/include/mock_access_remote.h
@@ -87,8 +87,7 @@ class MockAccessRemote : public AccessRemote {
                  const RemoteControlParams& params));
   MOCK_METHOD1(IsAppReverse, bool(const PTString& app_id));
   MOCK_METHOD0(Reset, void());
-  MOCK_CONST_METHOD2(GetDeviceZone, SeatLocation(const std::string& device_id,
-                                                 SeatLocation default_seat));
+  MOCK_CONST_METHOD1(GetDeviceZone, const SeatLocation*(const std::string& device_id));
   MOCK_METHOD2(SetDeviceZone, void(const std::string& device_id,
                                    const SeatLocation& zone));
 };

--- a/src/components/policy/test/policy_manager_impl_test.cc
+++ b/src/components/policy/test/policy_manager_impl_test.cc
@@ -440,7 +440,7 @@ TEST_F(PolicyManagerImplTest, CheckAccess_Result) {
       WillOnce(Return("dev1"));
   EXPECT_CALL(*access_remote, IsPrimaryDevice("dev1")).WillOnce(Return(false));
   EXPECT_CALL(*access_remote, IsEnabled()).WillOnce(Return(true));
-  EXPECT_CALL(*access_remote, GetDeviceZone("dev1", zone)).WillOnce(Return(zone));
+  EXPECT_CALL(*access_remote, GetDeviceZone("dev1")).WillOnce(Return(&zone));
   EXPECT_CALL(*access_remote, CheckParameters(_,_,_)).WillOnce(Return(kManual));
   EXPECT_CALL(*access_remote, Check(who, what)).
       WillOnce(Return(TypeAccess::kAllowed));
@@ -472,7 +472,7 @@ TEST_F(PolicyManagerImplTest, TwoDifferentDevice) {
       WillOnce(Return("dev2"));
   EXPECT_CALL(*access_remote, IsPrimaryDevice("dev2")).WillOnce(Return(false));
   EXPECT_CALL(*access_remote, IsEnabled()).WillOnce(Return(true));
-  EXPECT_CALL(*access_remote, GetDeviceZone("dev2", zone)).WillOnce(Return(zone));
+  EXPECT_CALL(*access_remote, GetDeviceZone("dev2")).WillOnce(Return(&zone));
   EXPECT_CALL(*access_remote, CheckParameters(_,_,_)).WillOnce(Return(kManual));
   EXPECT_CALL(*access_remote, Check(who2, what)).
         WillOnce(Return(TypeAccess::kDisallowed));

--- a/src/components/policy/test/policy_manager_impl_test.cc
+++ b/src/components/policy/test/policy_manager_impl_test.cc
@@ -440,7 +440,6 @@ TEST_F(PolicyManagerImplTest, CheckAccess_Result) {
       WillOnce(Return("dev1"));
   EXPECT_CALL(*access_remote, IsPrimaryDevice("dev1")).WillOnce(Return(false));
   EXPECT_CALL(*access_remote, IsEnabled()).WillOnce(Return(true));
-  EXPECT_CALL(*access_remote, GetDeviceZone("dev1")).WillOnce(Return(&zone));
   EXPECT_CALL(*access_remote, CheckParameters(_,_,_)).WillOnce(Return(kManual));
   EXPECT_CALL(*access_remote, Check(who, what)).
       WillOnce(Return(TypeAccess::kAllowed));
@@ -472,7 +471,6 @@ TEST_F(PolicyManagerImplTest, TwoDifferentDevice) {
       WillOnce(Return("dev2"));
   EXPECT_CALL(*access_remote, IsPrimaryDevice("dev2")).WillOnce(Return(false));
   EXPECT_CALL(*access_remote, IsEnabled()).WillOnce(Return(true));
-  EXPECT_CALL(*access_remote, GetDeviceZone("dev2")).WillOnce(Return(&zone));
   EXPECT_CALL(*access_remote, CheckParameters(_,_,_)).WillOnce(Return(kManual));
   EXPECT_CALL(*access_remote, Check(who2, what)).
         WillOnce(Return(TypeAccess::kDisallowed));


### PR DESCRIPTION
Policies: RSDL sends GetInteriorVehicleDataConsent with interiorZone from mobileApp instead of interiorZone provided by HMI