### PR TITLE
Add info into request if driver disallows remote control RPC

### DIFF
--- a/src/components/can_cooperation/src/command/base_command_request.cc
+++ b/src/components/can_cooperation/src/command/base_command_request.cc
@@ -476,7 +476,8 @@ void BaseCommandRequest::ProcessAccessResponse(
     CheckHMILevel(application_manager::kManual, allowed);
     Execute();  // run child's logic
   } else {
-    SendResponse(false, result_codes::kUserDisallowed, "");
+    SendResponse(false, result_codes::kUserDisallowed,
+                 "The driver disallows this remote-control RPC");
   }
 }
 


### PR DESCRIPTION
RSDL does NOT respond with info: "The driver disallows this remote-control RPC" to mobile application