### PR TITLE
REVSDL-1910 RSDL: HMI's RPCs validation rules: doesn't validate when …

### DIFF
--- a/src/components/can_cooperation/include/can_cooperation/can_module.h
+++ b/src/components/can_cooperation/include/can_cooperation/can_module.h
@@ -150,6 +150,12 @@ class CANModule : public functional_modules::GenericModule,
   void SubscribeOnFunctions();
   void NotifyMobiles(application_manager::MessagePtr msg);
 
+  void UnsubscribeAppsFromInteriorZone(uint32_t  device_id,
+                                      const Json::Value& interior_zone);
+
+  void NotifyHMIAboutUnsubscription(uint32_t hmi_app_id,
+                                    const Json::Value& module_description);
+
   functional_modules::ProcessResult HandleMessage(
     application_manager::MessagePtr msg);
   // TODO(VS): must be uid

--- a/src/components/can_cooperation/src/validators/struct_validators/rds_data_validator.cc
+++ b/src/components/can_cooperation/src/validators/struct_validators/rds_data_validator.cc
@@ -90,7 +90,7 @@ RdsDataValidator::RdsDataValidator() {
   // name="REG"
   reg_[ValidationParams::TYPE] = ValueType::STRING;
   reg_[ValidationParams::MIN_LENGTH] = 0;
-  reg_[ValidationParams::MAX_LENGTH] = 100;
+  reg_[ValidationParams::MAX_LENGTH] = 255;
   reg_[ValidationParams::ARRAY] = 0;
   reg_[ValidationParams::MANDATORY] = 1;
 


### PR DESCRIPTION
…HMI responds GetInteriorVehicleData message with "REG" parameter out of bounds