### PR TITLE
REVSDL-2255 RSDL: the "GENERIC_ERROR" instead of "UNSUPPORTED_RESOURS…

### DIFF
--- a/src/components/can_cooperation/src/command/get_interior_vehicle_data_capabilities_request.cc
+++ b/src/components/can_cooperation/src/command/get_interior_vehicle_data_capabilities_request.cc
@@ -127,10 +127,6 @@ void GetInteriorVehicleDataCapabiliesRequest::OnEvent(
         success = true;
         result_code = result_codes::kSuccess;
         info = "";
-      } else {
-        response_params_.removeMember(kInteriorVehicleDataCapabilities);
-        result_code = result_codes::kGenericError;
-        info = "Invalid response from the vehicle";
       }
     }
 

--- a/src/components/can_cooperation/src/module_helper.cc
+++ b/src/components/can_cooperation/src/module_helper.cc
@@ -161,7 +161,7 @@ functional_modules::ProcessResult ModuleHelper::ProcessSDLActivateApp(
           }
         }
       }
-      if (active_app == new_app) {
+      if ((!new_app) || (active_app == new_app)) {
         return ProcessResult::CANNOT_PROCESS;
       }
 


### PR DESCRIPTION
…E" result when the app from DRIVER's device requesting remote-control "GetInteriorVehicleDataCapabilities" RPC with unsupported zones