### PR TITLE
Integration of socket wrapper

### DIFF
--- a/src/components/include/utils/macro.h
+++ b/src/components/include/utils/macro.h
@@ -141,4 +141,6 @@ friend class test_case_name##_##test_name##_Test
 #define FRIEND_TEST(test_case_name, test_name)
 #endif  // BUILD_TESTS
 
+#define UNUSED(x) (void) x;
+
 #endif  // SRC_COMPONENTS_INCLUDE_UTILS_MACRO_H_

--- a/src/components/ivdcm_module/CMakeLists.txt
+++ b/src/components/ivdcm_module/CMakeLists.txt
@@ -48,6 +48,8 @@ set (LIBRARIES
     ApplicationManager
     FunctionalModule
     Utils
+    Transmitter
+    Net
 )
 
 add_library(${target} SHARED ${SOURCES})
@@ -69,6 +71,9 @@ install(
   FILES ${FILES_FOR_COPY}
   DESTINATION ${install_destination}
 )
+
+add_subdirectory(net)
+add_subdirectory(transmitter)
 
 if(BUILD_TESTS)
   add_subdirectory(test)

--- a/src/components/ivdcm_module/net/CMakeLists.txt
+++ b/src/components/ivdcm_module/net/CMakeLists.txt
@@ -1,0 +1,17 @@
+set(NET_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+
+file(GLOB SOURCES
+  ${NET_DIR}/src/*
+)
+
+set(LIBRARIES
+)
+
+include_directories(
+  ${NET_DIR}/..
+  ${CMAKE_SOURCE_DIR}/src/components/utils
+)
+
+add_library("Net" ${SOURCES})
+
+target_link_libraries("Net" ${LIBRARIES})

--- a/src/components/ivdcm_module/net/connected_socket.h
+++ b/src/components/ivdcm_module/net/connected_socket.h
@@ -1,0 +1,116 @@
+#ifndef SRC_COMPONENTS_IVDCM_MODULE_NET_CONNECTED_SOCKET_H_
+#define SRC_COMPONENTS_IVDCM_MODULE_NET_CONNECTED_SOCKET_H_
+
+#include <net/socket.h>
+
+namespace net {
+
+/**
+ * Generic client socket operations abstraction
+ */
+class ConnectedSocket : public Socket {
+ public:
+  /**
+   * Default constructor
+   *
+   * @param family  Specifies socket communication domain
+   * @param address Specifies socket address. In case of NET_AF_UNIX specifies
+   *pathname
+   * @param port    Specifies socket port. In case of NET_AF_UNIX will be
+   *omitted
+   */
+  ConnectedSocket(Domain domain, const char* address, UInt32 port);
+
+  /**
+   * Default Destructor
+   */
+  virtual ~ConnectedSocket();
+
+  /**
+     * Sets options on socket
+     * Wrapper around the setsockopt system call.
+     */
+  virtual bool set_opt(Int32 level, Int32 optname, const void* optval,
+                       socklen_t optlen);
+
+  /**
+   * Closes socket
+   */
+  virtual void close();
+
+  /**
+   * Shudowns socket using SHUT_RDWR option
+   */
+  virtual void shutdown();
+
+  /**
+   * Sets the blocking mode of this socket. If set to nonblocking,
+   * read/write calls will always return immediately, but possibly
+   * not all of the data has been read/written.
+   *
+   * @param is_blocking Whether to operate in blocking mode or not.
+   */
+  virtual void set_blocking_mode(bool is_blocking);
+
+  /**
+   * Sends size bytes over socket.
+   *
+   * @param buffer Data to send
+   * @param size   Number of bytes to send
+   * @param flags  The flags argument
+   *
+   * @return number of bytes sent.
+   */
+  virtual ssize_t send(const UInt8* buffer, size_t size, Int32 flags) = 0;
+
+  /**
+   * Sends file descriptor in control messages(ancillary data)
+   *
+   * @param file_fd The file descriptor to send
+   * @param flags   The flags argument
+   *
+   * @return number of bytes sent.
+   */
+  virtual ssize_t send(Int32 file_fd, Int32 flags) = 0;
+
+  /**
+   * Reads bytes from socket. This function call may return a value lower than
+   *size in case of
+   * signals interrupting the call.
+   *
+   * @param buffer buffer for read data
+   * @param size Maximum number of bytes that could be read
+   * @param flags  The flags argument
+   *
+   * @return number of bytes read.
+   */
+  virtual ssize_t recv(UInt8* buffer, size_t size, Int32 flags) = 0;
+
+  /**
+   * Reads from socket control-related messages
+   *
+   * @param msg msghdr structure
+   * @param flags  The flags argument
+   *
+   * @return number of bytes read.
+   */
+  virtual ssize_t recv(struct msghdr* msg, Int32 flags) = 0;
+
+  virtual bool connect() = 0;
+
+ protected:
+  ConnectedSocket(Domain domain, Int32 handle);
+
+  /**
+   * Connects a client to a remote server socket.
+   *
+   * @return TRUE in case of success, otherwise FALSE.
+   *
+   */
+
+ private:
+};
+
+}  // namespace net
+
+#endif  // SRC_COMPONENTS_IVDCM_MODULE_NET_CONNECTED_SOCKET_H_

--- a/src/components/ivdcm_module/net/connected_socket_impl.h
+++ b/src/components/ivdcm_module/net/connected_socket_impl.h
@@ -1,0 +1,149 @@
+#ifndef SRC_COMPONENTS_IVDCM_MODULE_NET_CONNECTED_SOCKET_IMPL_H_
+#define SRC_COMPONENTS_IVDCM_MODULE_NET_CONNECTED_SOCKET_IMPL_H_
+
+#include <net/connected_socket.h>
+#include <net/server_socket_impl.h>
+
+namespace net {
+
+/**
+ * Generic client socket operations implementation
+ */
+class ConnectedSocketImpl : public virtual ConnectedSocket {
+ public:
+  /**
+   * Default constructor
+   *
+   * @param address Specifies socket address
+   * @param port    Specifies socket port
+   */
+  ConnectedSocketImpl(const char* address, UInt32 port);
+
+  friend class ServerSocketImpl;
+
+  /**
+   * Provides connected socket to the remote host
+   *
+   * @param address Specifies socket address
+   * @param port    Specifies socket port
+   * @param attempts    attempts to connect to host.
+   * It attempts = 0, try to connecto to  host infinitely
+   *
+   * @return ConnectedSocket object, that must be deleted by caller
+   */
+  static ConnectedSocket* ConnectToHost(const char* address, UInt32 port,
+                                        UInt32 attempts = 30);
+
+  /**
+   * Provides connected socket to the local host
+   *
+   * @param path_name Specifies socket path
+   *
+   * @return ConnectedSocket object, that must be deleted by caller
+   */
+  static ConnectedSocket* ConnectToHost(const char* path_name);
+
+  /**
+   * Default Destructor
+   */
+  virtual ~ConnectedSocketImpl();
+
+  /**
+   * Sets options on socket
+   * Wrapper around the setsockopt system call.
+   */
+  virtual bool set_opt(Int32 level, Int32 optname, const void* optval,
+                       socklen_t optlen);
+
+  /**
+   * Closes socket
+   */
+  virtual void close();
+
+  /**
+   * Shudowns socket using SHUT_RDWR option
+   */
+  virtual void shutdown();
+
+  /**
+   * Sets the blocking mode of this socket. If set to nonblocking,
+   * read/write calls will always return immediately, but possibly
+   * not all of the data has been read/written.
+   *
+   * @param is_blocking Whether to operate in blocking mode or not.
+   */
+  virtual void set_blocking_mode(bool is_blocking);
+
+  /**
+   * Sends size bytes over socket.
+   *
+   * @param buffer Data to send
+   * @param size   Number of bytes to send
+   * @param flags  The flags argument
+   *
+   * @return number of bytes sent.
+   */
+  virtual ssize_t send(const UInt8* buffer, size_t size, Int32 flags);
+
+  /**
+   * Sends file descriptor in control messages(ancillary data)
+   *
+   * @param file_fd The file descriptor to send
+   * @param flags   The flags argument
+   *
+   * @return number of bytes sent.
+   */
+  virtual ssize_t send(Int32 file_fd, Int32 flags);
+
+  /**
+   * Reads bytes from socket. This function call may return a value lower than
+   *size in case of
+   * signals interrupting the call.
+   *
+   * @param buffer buffer for read data
+   * @param size Maximum number of bytes that could be read
+   * @param flags  The flags argument
+   *
+   * @return number of bytes read.
+   */
+  virtual ssize_t recv(UInt8* buffer, size_t, Int32 flags);
+
+  /**
+   * Reads from socket control-related messages
+   *
+   * @param msg msghdr structure
+   * @param flags  The flags argument
+   *
+   * @return number of bytes read.
+   */
+  virtual ssize_t recv(struct msghdr* msg, Int32 flags);
+
+ protected:
+  /**
+ * Connects a client to a remote server socket.
+ *
+ * @return TRUE in case of success, otherwise FALSE.
+ *
+ */
+  virtual bool connect();
+
+ private:
+  /**
+   * Default constructor for AF_UNIX domain sockets
+   *
+   * @param path_name   Specifies socket communication domain
+   */
+  explicit ConnectedSocketImpl(const char* path_name);
+
+  /**
+   * Constructor used by Server to create accepted connection
+   *
+   * @param domain    Specifies socket domain
+   * @param handle    Specifies socket handle returned by accept call
+   */
+  ConnectedSocketImpl(Domain domain, Int32 handle);
+};
+
+}  // namespace net
+
+#endif  // SRC_COMPONENTS_IVDCM_MODULE_NET_CONNECTED_SOCKET_IMPL_H_

--- a/src/components/ivdcm_module/net/server_socket.h
+++ b/src/components/ivdcm_module/net/server_socket.h
@@ -1,0 +1,79 @@
+#ifndef SRC_COMPONENTS_IVDCM_MODULE_NET_SERVER_SOCKET_H_
+#define SRC_COMPONENTS_IVDCM_MODULE_NET_SERVER_SOCKET_H_
+
+#include <net/socket.h>
+
+namespace net {
+
+class ConnectedSocket;
+
+/**
+ * Generic server socket operations abstraction
+ */
+class ServerSocket: public Socket {
+ public:
+  /**
+   * Default constructor
+   *
+   * @param family  Specifies socket communication domain
+   * @param address Specifies socket address. In case of NET_AF_UNIX specifies pathname
+   * @param port    Specifies socket port. In case of NET_AF_UNIX will be omitted
+   */
+  ServerSocket(Domain domain, const char* address, UInt32 port);
+
+  /**
+   * Default Destructor
+   */
+  virtual ~ServerSocket();
+
+  /**
+   * Sets options on socket
+   * Wrapper around the setsockopt system call.
+   */
+  virtual bool set_opt(Int32 level, Int32 optname,
+               const void* optval, socklen_t optlen);
+
+  /**
+   * Closes socket
+   */
+  virtual void close();
+
+  /**
+   * Shudowns socket using SHUT_RDWR option
+   */
+  virtual void shutdown();
+
+  /**
+   * Sets the blocking mode of this socket. If set to nonblocking,
+   * read/write calls will always return immediately, but possibly
+   * not all of the data has been read/written.
+   *
+   * @param is_blocking Whether to operate in blocking mode or not.
+   */
+  virtual void set_blocking_mode(bool is_blocking);
+
+  /**
+   * Binds the socket to the specified address.
+   */
+  virtual bool bind() = 0;
+
+  /**
+   * Puts the given socket in listen mode, so that it can accept
+   * incoming connection requests.
+   *
+   * @param backlog How many connection requests should be queued
+   *
+   */
+  virtual bool listen(Int32 backlog) = 0;
+
+  /**
+   * Accepts connection on the socket
+   * @return descriptor for the accepted socket. In case of fail INVALID_SOCKET will be returned
+   *
+   */
+  virtual ConnectedSocket* accept() = 0;
+};
+
+}  // namespace net
+
+#endif  // SRC_COMPONENTS_IVDCM_MODULE_NET_SERVER_SOCKET_H_

--- a/src/components/ivdcm_module/net/server_socket_impl.h
+++ b/src/components/ivdcm_module/net/server_socket_impl.h
@@ -1,0 +1,85 @@
+#ifndef SRC_COMPONENTS_IVDCM_MODULE_NET_SERVER_SOCKET_IMPL_H_
+#define SRC_COMPONENTS_IVDCM_MODULE_NET_SERVER_SOCKET_IMPL_H_
+
+#include <net/server_socket.h>
+
+namespace net {
+
+/**
+ * Generic server socket operations implementation
+ */
+class ServerSocketImpl: public virtual ServerSocket {
+ public:
+  /**
+   * Default constructor for AF_INET domain socket
+   *
+   * @param family  Specifies socket communication domain
+   * @param address Specifies socket address.
+   * @param port    Specifies socket port.
+   */
+  ServerSocketImpl(const char* address, UInt32 port);
+
+  /**
+   * Default constructor for AF_UNIX domain sockets
+   *
+   * @param path_name   Specifies socket communication domain
+   */
+  explicit ServerSocketImpl(const char* path_name);
+
+  /**
+   * Default Destructor
+   */
+  virtual ~ServerSocketImpl();
+
+  /**
+   * Sets options on socket
+   * Wrapper around the setsockopt system call.
+   */
+  virtual bool set_opt(Int32 level, Int32 optname,
+               const void* optval, socklen_t optlen);
+
+  /**
+   * Closes socket
+   */
+  virtual void close();
+
+  /**
+   * Shudowns socket using SHUT_RDWR option
+   */
+  virtual void shutdown();
+
+  /**
+   * Sets the blocking mode of this socket. If set to nonblocking,
+   * read/write calls will always return immediately, but possibly
+   * not all of the data has been read/written.
+   *
+   * @param is_blocking Whether to operate in blocking mode or not.
+   */
+  virtual void set_blocking_mode(bool is_blocking);
+
+  /**
+   * Binds the socket to the specified address.
+
+   */
+  virtual bool bind();
+
+  /**
+   * Puts the given socket in listen mode, so that it can accept
+   * incoming connection requests.
+   *
+   * @param backlog How many connection requests should be queued,
+   * defaults to 1
+   */
+  virtual bool listen(Int32 backlog = 1);
+
+  /**
+   * Accepts connection on the socket
+   * @return descriptor for the accepted socket. In case of fail INVALID_SOCKET will be returned
+   *
+   */
+  virtual ConnectedSocket* accept();
+};
+
+}  // namespace net
+
+#endif  // SRC_COMPONENTS_IVDCM_MODULE_NET_SERVER_SOCKET_IMPL_H_

--- a/src/components/ivdcm_module/net/socket.h
+++ b/src/components/ivdcm_module/net/socket.h
@@ -1,0 +1,137 @@
+#ifndef SRC_COMPONENTS_IVDCM_MODULE_NET_SOCKET_H_
+#define SRC_COMPONENTS_IVDCM_MODULE_NET_SOCKET_H_
+
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <string>
+#include "utils/types.h"
+#include "utils/macro.h"
+
+namespace net {
+
+#define INVALID_SOCKET -1
+
+/**
+* Socket address family.
+*/
+enum Domain { NET_AF_UNIX = AF_UNIX, NET_AF_INET = AF_INET };
+
+/**
+* Socket address family.
+*/
+enum { NET_MSG_DONTWAIT = MSG_DONTWAIT, NET_MSG_NOSIGNAL = MSG_NOSIGNAL };
+
+/**
+ * Generic socket operations abstraction
+ */
+class Socket {
+ public:
+  /**
+   * Default constructor
+   *
+   * @param family  Specifies socket communication domain
+   * @param address Specifies socket address. In case of NET_AF_UNIX specifies
+   *pathname
+   * @param port    Specifies socket port. In case of NET_AF_UNIX will be
+   *omitted
+   */
+  Socket(Domain domain, const char* address, UInt32 port);
+
+  /**
+   * Default Destructor
+   */
+  virtual ~Socket();
+
+  /**
+   * Sets options on socket
+   * Wrapper around the setsockopt system call.
+   */
+  virtual bool set_opt(Int32 level, Int32 optname, const void* optval,
+                       socklen_t optlen) = 0;
+
+  /**
+   * Closes socket
+   */
+  virtual void close() = 0;
+
+  /**
+   * Shudowns socket using SHUT_RDWR option
+   */
+  virtual void shutdown() = 0;
+
+  /**
+   * Sets the blocking mode of this socket. If set to nonblocking,
+   * read/write calls will always return immediately, but possibly
+   * not all of the data has been read/written.
+   *
+   * @param is_blocking Whether to operate in blocking mode or not.
+   */
+  virtual void set_blocking_mode(bool is_blocking) = 0;
+
+  /**
+   * Returns socket domain type
+   */
+  inline Domain domain() const;
+
+  /**
+   * Returns socket handle
+   */
+  inline Int32 socket_handle() const;
+
+  /**
+   * Returns socket port number
+   */
+  inline UInt32 port() const;
+
+  /**
+   * Returns socket address
+   */
+  const char* address() const;
+
+  /**
+   * Check whether the socket is blocking or not.
+   *
+   * @return true if the socket is in blocking mode.
+   */
+  bool is_blocking() const;
+
+  /**
+   * @brief Gets socket state.
+   * @return TRUE if it is connected otherwise FALSE
+   */
+  inline bool is_connected() const;
+
+  /**
+   * @brief Checks socket file descriptor
+   * @return TRUE if it is valid otherwise FALSE
+   */
+  bool is_valid() const;
+
+ protected:
+  Socket(Domain domain, Int32 handle);
+
+  /**
+   * @brief Creates a socket handle.
+   */
+  void create_socket();
+
+ private:
+  Domain domain_;
+  std::string address_;
+  Int32 port_number_;
+  Int32 socket_;
+};
+
+inline Domain Socket::domain() const { return domain_; }
+
+inline Int32 Socket::socket_handle() const { return socket_; }
+
+inline UInt32 Socket::port() const { return port_number_; }
+
+inline const char* Socket::address() const { return address_.c_str(); }
+
+bool Socket::is_connected() const { return socket_ != INVALID_SOCKET; }
+
+}  // namespace net
+
+#endif  // SRC_COMPONENTS_IVDCM_MODULE_NET_SOCKET_H_

--- a/src/components/ivdcm_module/net/src/connected_socket.cc
+++ b/src/components/ivdcm_module/net/src/connected_socket.cc
@@ -1,0 +1,35 @@
+#include "net/connected_socket.h"
+
+namespace net {
+
+ConnectedSocket::ConnectedSocket(Domain domain, const char* address, UInt32 port)
+  : Socket(domain, address, port) {
+}
+
+ConnectedSocket::ConnectedSocket(Domain domain, Int32 handle)
+  : Socket(domain, handle) {
+}
+
+ConnectedSocket::~ConnectedSocket() {
+  shutdown();
+  close();
+}
+
+bool ConnectedSocket::set_opt(Int32 level, Int32 optname,
+                     const void* optval, socklen_t opt_len) {
+  return Socket::set_opt(level, optname, optval, opt_len);
+}
+
+void ConnectedSocket::close() {
+  Socket::close();
+}
+
+void ConnectedSocket::shutdown() {
+  Socket::shutdown();
+}
+
+void ConnectedSocket::set_blocking_mode(bool is_blocking) {
+  Socket::set_blocking_mode(is_blocking);
+}
+
+}  // namespace net

--- a/src/components/ivdcm_module/net/src/connected_socket_impl.cc
+++ b/src/components/ivdcm_module/net/src/connected_socket_impl.cc
@@ -1,0 +1,216 @@
+#include "net/connected_socket_impl.h"
+
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <sys/un.h>
+#include <arpa/inet.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "utils/logger.h"
+
+CREATE_LOGGERPTR_GLOBAL(logger_, "IVDCM")
+
+namespace net {
+
+ConnectedSocket* ConnectedSocketImpl::ConnectToHost(const char* address,
+                                                    UInt32 port,
+                                                    UInt32 attempts) {
+  ConnectedSocket* socket = new ConnectedSocketImpl(address, port);
+  UInt32 count = 0;
+  while (!socket->connect()) {
+    LOG4CXX_ERROR(logger_, "Unable to connect " << address << ":" << port);
+    delete socket;
+    socket = new ConnectedSocketImpl(address, port);
+    sleep(1);
+    if (attempts != 0 && ++count == attempts) {
+      LOG4CXX_INFO(
+          logger_,
+          "Unable to connect " << address << ":" << port << " with " << attempts << " attempts");
+      delete socket;
+      return NULL;
+    }
+  }
+  LOG4CXX_ERROR(logger_, "Connected to connect " << address << ":" << port);
+  return socket;
+}
+
+ConnectedSocket* ConnectedSocketImpl::ConnectToHost(const char* path_name) {
+  ConnectedSocket* socket = new ConnectedSocketImpl(path_name);
+  if (!socket->connect()) {
+    LOG4CXX_ERROR(logger_, "Unable to connect to " << path_name);
+    delete socket;
+    return NULL;
+  }
+  return socket;
+}
+
+ConnectedSocketImpl::ConnectedSocketImpl(const char* address, UInt32 port)
+    : ConnectedSocket(NET_AF_INET, address, port) {}
+
+ConnectedSocketImpl::ConnectedSocketImpl(const char* path_name)
+    : ConnectedSocket(NET_AF_UNIX, path_name, 0) {}
+
+ConnectedSocketImpl::ConnectedSocketImpl(Domain domain, Int32 handle)
+    : ConnectedSocket(domain, handle) {}
+
+ConnectedSocketImpl::~ConnectedSocketImpl() {}
+
+bool ConnectedSocketImpl::set_opt(Int32 level, Int32 optname,
+                                  const void* optval, socklen_t opt_len) {
+  return ConnectedSocket::set_opt(level, optname, optval, opt_len);
+}
+
+void ConnectedSocketImpl::close() { ConnectedSocket::close(); }
+
+void ConnectedSocketImpl::shutdown() { ConnectedSocket::shutdown(); }
+
+void ConnectedSocketImpl::set_blocking_mode(bool is_blocking) {
+  ConnectedSocket::set_blocking_mode(is_blocking);
+}
+
+bool ConnectedSocketImpl::connect() {
+  DCHECK_OR_RETURN(socket_handle() != INVALID_SOCKET, false);
+  struct sockaddr_in addr_in = {0};
+  struct sockaddr_un addr_un = {0};
+  struct sockaddr* addr = NULL;
+  socklen_t len = 0;
+
+  if (NET_AF_UNIX == domain()) {
+    addr_un.sun_family = domain();
+    memcpy(addr_un.sun_path, address(), sizeof(addr_un.sun_path));
+    addr = reinterpret_cast<struct sockaddr*>(&addr_un);
+    len = sizeof(addr_un);
+  } else {
+    addr_in.sin_addr.s_addr = inet_addr(address());
+    addr_in.sin_family = domain();
+    addr_in.sin_port = htons(port());
+    addr = reinterpret_cast<struct sockaddr*>(&addr_in);
+    len = sizeof(addr_in);
+  }
+
+  if (-1 == ::connect(socket_handle(), addr, len)) {
+    LOG4CXX_ERROR(logger_, "Unable to connect to the server " << strerror(errno));
+    return false;
+  }
+
+  return true;
+}
+
+ssize_t ConnectedSocketImpl::send(const UInt8* buffer, size_t size,
+                                  Int32 flags) {
+  ssize_t ret;
+  if (-1 == (ret = ::send(socket_handle(), buffer, size, flags))) {
+    LOG4CXX_ERROR(logger_, "Unable to send " << strerror(errno));
+  }
+
+  return ret;
+}
+
+ssize_t ConnectedSocketImpl::send(Int32 file_fd, Int32 flags) {
+  ssize_t ret = -1;
+
+  if (NET_AF_UNIX != domain()) {
+    return ret;
+  }
+
+  /* We are passing at least one byte of data so that recvmsg() will not return
+   * 0 */
+  char data[1];
+  data[0] = ' ';
+
+  /* The struct iovec below is part of a scatter-gather list.  It describes a
+     buffer.  In this case, it describes a buffer (an integer) containing the
+     data that we're going to send back
+  */
+  struct iovec iov[1];
+  iov[0].iov_base = data;
+  iov[0].iov_len = sizeof(data);
+
+  /* The CMSG macros yused to create and access control
+     messages (which is another name for ancillary data). The ancillary
+     data is made up of pairs of struct cmsghdr structures and associated
+     data arrays. First, we're going to allocate a buffer on the stack to
+     contain our
+     data array (that contains the socket).
+  */
+  struct cmsghdr* cmp;
+  cmp = static_cast<cmsghdr*>(malloc(CMSG_SPACE(sizeof(int))));
+
+  /* There is a msghdr that is used to minimize the number of parameters
+     passed to sendmsg (which we will use to send our ancillary data).  This
+     structure uses terminology corresponding to control messages, so you'll
+     see msg_control, which is the pointer to the ancillary data and controllen
+     which is the size of the ancillary data array.
+
+     So, initialize the message header that describes our ancillary/control data
+     and point it to the control message/ancillary data we just allocated space
+     for.
+     */
+  struct msghdr message;
+  memset(&message, 0, sizeof(struct msghdr));
+  message.msg_name = NULL;
+  message.msg_namelen = 0;
+  message.msg_iov = iov;
+  message.msg_iovlen = 1;
+
+  message.msg_controllen = CMSG_SPACE(sizeof(int));
+  message.msg_control = cmp;
+
+  /* A cmsghdr contains a length field that is the length of the header and
+     the data.  It has a cmsg_level field corresponding to the originating
+     protocol.  This takes values which are legal levels for getsockopt and
+     setsockopt (here SOL_SOCKET).  We're going to use the SCM_RIGHTS type of
+     cmsg, that indicates that the ancillary data array contains access rights
+     that we are sending back .
+
+     We have to put together the first (and only) cmsghdr that will describe
+     the whole package we're sending.
+  */
+  struct cmsghdr* control_message = NULL;
+  control_message = CMSG_FIRSTHDR(&message);
+  control_message->cmsg_level = SOL_SOCKET;
+  control_message->cmsg_type = SCM_RIGHTS;
+  control_message->cmsg_len = CMSG_LEN(sizeof(int));
+
+  /* We also have to update the controllen in case other stuff is actually
+     in there we may not be aware of (due to macros)
+  */
+  message.msg_controllen = control_message->cmsg_len;
+
+  /* get a pointer to the start of the ancillary data array and
+     put our file descriptor in.
+  */
+  *((int*)CMSG_DATA(control_message)) = file_fd;
+
+  // send the file descriptor
+  if (-1 == (ret = ::sendmsg(socket_handle(), &message, flags))) {
+    LOG4CXX_ERROR(logger_, "Unable to send " << strerror(errno));
+    free(cmp);
+  }
+
+  free(cmp);
+  return ret;
+}
+
+ssize_t ConnectedSocketImpl::recv(UInt8* buffer, size_t size, Int32 flags) {
+  ssize_t ret;
+  if (-1 == (ret = ::recv(socket_handle(), reinterpret_cast<void*>(buffer),
+                          size, flags))) {
+    LOG4CXX_ERROR(logger_, "Unable to recv " << strerror(errno));
+  }
+
+  return ret;
+}
+
+ssize_t ConnectedSocketImpl::recv(struct msghdr* msg, Int32 flags) {
+  ssize_t ret;
+  if (-1 == (ret = ::recvmsg(socket_handle(), msg, flags))) {
+    LOG4CXX_ERROR(logger_, "Unable to recvmsg " << strerror(errno));
+  }
+
+  return ret;
+}
+
+}  // namespace net

--- a/src/components/ivdcm_module/net/src/server_socket.cc
+++ b/src/components/ivdcm_module/net/src/server_socket.cc
@@ -1,0 +1,35 @@
+#include "net/server_socket.h"
+#include "utils/logger.h"
+
+CREATE_LOGGERPTR_GLOBAL(logger_, "IVDCM")
+
+namespace net {
+
+ServerSocket::ServerSocket(Domain domain, const char* address, UInt32 port)
+  : Socket(domain, address, port) {
+}
+
+ServerSocket::~ServerSocket() {
+  LOG4CXX_AUTO_TRACE(logger_);
+  shutdown();
+  close();
+}
+
+bool ServerSocket::set_opt(Int32 level, Int32 optname,
+                     const void* optval, socklen_t opt_len) {
+  return Socket::set_opt(level, optname, optval, opt_len);
+}
+
+void ServerSocket::close() {
+  Socket::close();
+}
+
+void ServerSocket::shutdown() {
+  Socket::shutdown();
+}
+
+void ServerSocket::set_blocking_mode(bool is_blocking) {
+  Socket::set_blocking_mode(is_blocking);
+}
+
+}  // namespace net

--- a/src/components/ivdcm_module/net/src/server_socket_impl.cc
+++ b/src/components/ivdcm_module/net/src/server_socket_impl.cc
@@ -1,0 +1,97 @@
+#include "net/server_socket_impl.h"
+
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <sys/un.h>
+#include <arpa/inet.h>
+#include <errno.h>
+
+#include "net/connected_socket_impl.h"
+#include "utils/logger.h"
+
+CREATE_LOGGERPTR_GLOBAL(logger_, "IVDCM")
+
+namespace net {
+
+ServerSocketImpl::ServerSocketImpl(const char* address, UInt32 port)
+    : ServerSocket(NET_AF_INET, address, port) {}
+
+ServerSocketImpl::ServerSocketImpl(const char* path_name)
+    : ServerSocket(NET_AF_UNIX, path_name, 0) {}
+
+ServerSocketImpl::~ServerSocketImpl() {}
+
+bool ServerSocketImpl::set_opt(Int32 level, Int32 optname, const void* optval,
+                               socklen_t opt_len) {
+  return ServerSocket::set_opt(level, optname, optval, opt_len);
+}
+
+void ServerSocketImpl::close() { ServerSocket::close(); }
+
+void ServerSocketImpl::shutdown() { ServerSocket::shutdown(); }
+
+void ServerSocketImpl::set_blocking_mode(bool is_blocking) {
+  ServerSocket::set_blocking_mode(is_blocking);
+}
+
+bool ServerSocketImpl::bind() {
+  struct sockaddr_in addr_in = {0};
+  struct sockaddr_un addr_un = {0};
+  struct sockaddr* addr = NULL;
+  socklen_t len = 0;
+
+  if (NET_AF_UNIX == domain()) {
+    addr_un.sun_family = domain();
+    memcpy(addr_un.sun_path, address(), sizeof(addr_un.sun_path));
+    addr = reinterpret_cast<struct sockaddr*>(&addr_un);
+    len = sizeof(addr_un);
+  } else {
+    addr_in.sin_addr.s_addr = inet_addr(address());
+    addr_in.sin_family = domain();
+    addr_in.sin_port = htons(port());
+    addr = reinterpret_cast<struct sockaddr*>(&addr_in);
+    len = sizeof(addr_in);
+  }
+
+  if (-1 == ::bind(socket_handle(), addr, len)) {
+    std::string error(strerror(errno));
+    LOG4CXX_FATAL(
+        logger_,
+        "Unable to bind to " <<  address() << ":" << port() << ". " << error);
+    return false;
+  }
+
+  return true;
+}
+
+bool ServerSocketImpl::listen(Int32 backlog) {
+  if (-1 == ::listen(socket_handle(), backlog)) {
+    std::string error(strerror(errno));
+    LOG4CXX_FATAL(
+            logger_,
+            "Unable to listen. " << error);
+    return false;
+  }
+
+  return true;
+}
+
+ConnectedSocket* ServerSocketImpl::accept() {
+  Int32 new_socket_fd = INVALID_SOCKET;
+  ConnectedSocket* connected_socket = NULL;
+
+  // The returned address is ignored
+  LOG4CXX_INFO(logger_, "Accept connection on " << address() << ":" << port());
+  new_socket_fd = ::accept(socket_handle(), NULL, NULL);
+  if (0 > new_socket_fd) {
+    std::string error(strerror(errno));
+    LOG4CXX_ERROR(logger_, "Unable to accept " << error);
+    return connected_socket;
+  }
+
+  connected_socket = new ConnectedSocketImpl(domain(), new_socket_fd);
+  LOG4CXX_INFO(logger_, "Accepted new connection on " << address() << ":" << port());
+  return connected_socket;
+}
+
+}  // namespace net

--- a/src/components/ivdcm_module/net/src/socket.cc
+++ b/src/components/ivdcm_module/net/src/socket.cc
@@ -1,0 +1,85 @@
+#include "net/socket.h"
+
+#include <fcntl.h>
+#include <sys/types.h>
+#include <netdb.h>
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <sys/un.h>
+#include <stdio.h>
+#include <errno.h>
+#include <unistd.h>
+
+#include "utils/logger.h"
+
+CREATE_LOGGERPTR_GLOBAL(logger_, "IVDCM")
+
+namespace net {
+
+Socket::Socket(Domain domain, const char* address, UInt32 port)
+    : domain_(domain),
+      address_(address),
+      port_number_(port),
+      socket_(INVALID_SOCKET) {
+  create_socket();
+}
+
+Socket::Socket(Domain domain, Int32 handle)
+    : domain_(domain), address_(), port_number_(), socket_(handle) {}
+
+Socket::~Socket() {}
+
+bool Socket::set_opt(Int32 level, Int32 optname, const void* optval,
+                     socklen_t opt_len) {
+  if (-1 == setsockopt(socket_, level, optname,
+                       static_cast<const void*>(&optval),
+                       static_cast<socklen_t>(sizeof opt_len))) {
+    LOG4CXX_FATAL(logger_, "Unable to set sockopt " << strerror(errno));
+    return false;
+  }
+
+  return true;
+}
+
+void Socket::close() {
+  if (INVALID_SOCKET == socket_) {
+    LOG4CXX_WARN(logger_, "Trying to close invalid socket");
+    return;
+  }
+
+  if (-1 == ::close(socket_)) {
+    LOG4CXX_ERROR(logger_, "Unable to close socket " << strerror(errno));
+    return;
+  }
+  socket_ = INVALID_SOCKET;
+}
+
+void Socket::shutdown() {
+  if (INVALID_SOCKET == socket_) {
+    LOG4CXX_WARN(logger_, "Trying to close invalid socket");
+    return;
+  }
+
+  if (-1 == ::shutdown(socket_, SHUT_RDWR)) {
+    LOG4CXX_ERROR(logger_, "Unable to shutdown socket " << strerror(errno));
+    return;
+  }
+}
+
+void Socket::set_blocking_mode(bool is_blocking) {
+  if (is_blocking) {
+    ::fcntl(socket_, F_SETFL, ::fcntl(socket_, F_GETFL, 0) & ~O_NDELAY);
+  } else {
+    ::fcntl(socket_, F_SETFL, ::fcntl(socket_, F_GETFL, 0) | O_NDELAY);
+  }
+}
+
+void Socket::create_socket() {
+  // socket type is SOCK_STREAM by default
+  socket_ = socket(domain_, SOCK_STREAM, 0);
+  if (-1 == socket_) {
+    LOG4CXX_FATAL(logger_, "Unable to create socket " << strerror(errno));
+  }
+}
+
+}  // namespace net

--- a/src/components/ivdcm_module/transmitter/CMakeLists.txt
+++ b/src/components/ivdcm_module/transmitter/CMakeLists.txt
@@ -1,0 +1,18 @@
+set(TRANSMITTER_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+
+file(GLOB SOURCES
+  ${TRANSMITTER_DIR}/src/*
+)
+
+set(LIBRARIES
+    Utils
+)
+
+include_directories(
+  ${TRANSMITTER_DIR}/..
+  ${CMAKE_SOURCE_DIR}/src/components/utils
+)
+
+add_library("Transmitter" ${SOURCES})
+
+target_link_libraries("Transmitter" ${LIBRARIES})

--- a/src/components/ivdcm_module/transmitter/src/transmitter.cc
+++ b/src/components/ivdcm_module/transmitter/src/transmitter.cc
@@ -1,0 +1,109 @@
+#include "transmitter/transmitter.h"
+
+#include "net/connected_socket.h"
+#include "utils/scope_guard.h"
+#include "utils/macro.h"
+
+namespace transmitter {
+static const int HEADER_SIZE = sizeof(Int32);
+
+Int32 Transmitter::RecvSize() {
+  UInt8 result[HEADER_SIZE] = {0};
+  ssize_t received_size = socket_->recv(result, HEADER_SIZE, 0);
+  if (received_size < 0) {
+    return received_size;
+  }
+  DCHECK_OR_RETURN(received_size == HEADER_SIZE, -1);
+  const Int32 value = (Int32(result[0])) + (Int32(result[1]) << 8) +
+                      (Int32(result[2]) << 16) + (Int32(result[3]) << 24);
+  LOG4CXX_INFO(logger_, "Received size " << value);
+  return value;
+}
+
+bool Transmitter::SendSize(const std::string& str) {
+  DCHECK_OR_RETURN("Unable to send string with size = 0", false)
+  UInt32 value = str.size();
+  UInt8 result[HEADER_SIZE] = {0};
+  result[0] = (value & 0x000000ff);
+  result[1] = (value & 0x0000ff00) >> 8;
+  result[2] = (value & 0x00ff0000) >> 16;
+  result[3] = (value & 0xff000000) >> 24;
+  LOG4CXX_INFO(logger_, "Send size " << value);
+  return (socket_->send(result, HEADER_SIZE, 0) == 4);
+}
+
+bool Transmitter::Send(const std::string& to_send) {
+  DCHECK_OR_RETURN(socket_, false);
+  const size_t chunk = 1000;
+  size_t const total_size = to_send.size();
+  size_t size_to_send = 0;
+  UInt8* data_bytes = NULL;
+
+  if (to_send.size() < chunk) {
+    data_bytes = new UInt8[to_send.size()];
+    size_to_send = to_send.size();
+  } else {
+    data_bytes = new UInt8[chunk];
+    size_to_send = chunk;
+  }
+  utils::ScopeGuard ppsdata_guard =
+      utils::MakeGuard(utils::ArrayDeleter<UInt8*>, data_bytes);
+  UNUSED(ppsdata_guard);
+
+  SendSize(to_send);
+  LOG4CXX_INFO(logger_, "Send data " << to_send.size());
+  size_t data_sent = 0;
+  while (total_size > data_sent) {
+    memcpy(data_bytes, to_send.c_str() + data_sent, size_to_send);
+    size_t chunksent =
+        socket_->send(data_bytes, size_to_send, net::NET_MSG_NOSIGNAL);
+    data_sent += chunksent;
+    memset(data_bytes, 0, size_to_send);
+    if ((data_sent + chunk) > total_size) {
+      size_to_send = total_size - data_sent;
+    }
+  }
+  LOG4CXX_INFO(logger_, "Sent " << data_sent);
+  return true;
+}
+
+bool Transmitter::Recv(std::string* message) {
+  DCHECK_OR_RETURN(socket_, false);
+  const Int32 CHUNK_SIZE = 1000;
+  Int32 to_recv = CHUNK_SIZE;
+  Int32 wait_size = RecvSize();
+  if (wait_size < 0) {
+    LOG4CXX_ERROR(logger_, "Unable to receive message");
+    return false;
+  }
+  LOG4CXX_ERROR(logger_, "Waiting for " << wait_size << " bytes");
+  if (wait_size < to_recv) {
+    to_recv = wait_size;
+  }
+
+  Int32 received = 0;
+  UInt8* data_bytes = new UInt8[CHUNK_SIZE];
+
+  while (wait_size > received) {
+    ssize_t size = socket_->recv(data_bytes, to_recv, 0);
+    if (size <= 0) {
+      LOG4CXX_INFO(logger_, "recv error " << size);
+      return false;
+    }
+
+    std::string partial;
+    partial.assign(reinterpret_cast<char*>(data_bytes), size);
+    message->append(partial);
+    memset(data_bytes, 0, size);
+
+    received += size;  // Just for debug
+    if (received + CHUNK_SIZE > wait_size) {
+      to_recv = wait_size - received;
+    }
+  }
+
+  LOG4CXX_INFO(logger_, "Total received " << received);
+  LOG4CXX_INFO(logger_, "String size " << message->size());
+  return true;
+}
+}  // namespace transmitter

--- a/src/components/ivdcm_module/transmitter/transmitter.h
+++ b/src/components/ivdcm_module/transmitter/transmitter.h
@@ -1,0 +1,54 @@
+#ifndef SRC_COMPONENTS_IVDCM_MODULE_TRANSMITTER_TRANSMITTER_H_
+#define SRC_COMPONENTS_IVDCM_MODULE_TRANSMITTER_TRANSMITTER_H_
+#include <string>
+#include "utils/types.h"
+#include "utils/macro.h"
+#include "utils/logger.h"
+
+CREATE_LOGGERPTR_GLOBAL(logger_, "IVDCM")
+
+namespace net {
+class ConnectedSocket;
+}
+
+namespace transmitter {
+class Transmitter {
+ public:
+  explicit Transmitter(net::ConnectedSocket* socket = NULL)
+      : socket_(socket), stop_flag_(false) {}
+  bool Send(const std::string& to_send);
+  bool Recv(std::string* message);
+
+  template <class NotificationSubscriber>
+  void MessageListenLoop(NotificationSubscriber* subscriber) {
+    while (!stop_flag_) {
+      std::string buff;
+      if (!Recv(&buff)) {
+        LOG4CXX_ERROR(logger_, "Server is down");
+        return;
+      }
+      if (buff.size() > 0) {
+        subscriber->OnMessageReceived(buff);
+      } else {
+        LOG4CXX_WARN(logger_, "Received 0 bytes");
+      }
+    }
+  }
+  void Stop() { stop_flag_ = true; }
+
+ public:
+  void set_socket(net::ConnectedSocket* socket) {
+    DCHECK_OR_RETURN_VOID(socket);
+    // TODO delete socket_ if it exists
+    socket_ = socket;
+  }
+
+ private:
+  Int32 RecvSize();
+  bool SendSize(const std::string& str);
+  net::ConnectedSocket* socket_;
+  volatile bool stop_flag_;
+};
+
+}  // namespace transmitter
+#endif  // SRC_COMPONENTS_IVDCM_MODULE_TRANSMITTER_TRANSMITTER_H_

--- a/src/components/ivdcm_module/utils/scope_guard.h
+++ b/src/components/ivdcm_module/utils/scope_guard.h
@@ -1,0 +1,316 @@
+/*
+ * Copyright (c) 2015, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SRC_COMPONENTS_INCLUDE_UTILS_SCOPE_GUARD_H
+#define SRC_COMPONENTS_INCLUDE_UTILS_SCOPE_GUARD_H
+
+namespace utils {
+
+/**
+ * @brief The ScopeGuardImplBase class the class which allows to keep safety
+ * raw pointer within local scope. The same ScopeGuard has been provided by
+ * Andrej Alexandresku in the Loki library.
+ *
+ * The usage area example:
+ *
+ * Suppose user have to create some pointer in function call Init(). And in case
+ * of some fail condition this pointer has to be freed. So in order to avoid
+ * code duplicate as follows:
+ *
+ * bool SomeClass::Init() {
+ *   memberObject_ = custom_allocate() // initialize member object with some
+ *value
+ *   if(!some_condition) {
+ *     custom_release(memberObject();
+ *     return false;
+ *   }
+ *
+ * if(!other_condition) {
+ *   custom_release(memberObject)
+ *   return false;
+ * }
+ * return true;
+ * }
+ *
+ * The user is able to use ScopeGuard, where possible to automatically call
+ * custom release function. See example bellow:
+ *
+ * bool SomeClass::Init() {
+ *   memberObject_ = custom_allocate() // initialize member object with some
+ *value
+ *   // The guard will call custom release function when it goes out of scope.
+ *   ScopeGaurd guard = MakeGuard(custom_release, memberObject);
+ *   if(!some_condition) {
+ *     return false;
+ *   }
+ *
+ * if(!other_condition) {
+ *   return false;
+ * }
+ * // Here to avoid object releasing the user has to call Dismiss method.
+ * // So no custom release function will be called after return statement.
+ * guard.Dismiss();
+ * return true;
+ * }
+ */
+class ScopeGuardImplBase {
+ public:
+  /**
+   * @brief ScopeGuardImplBase the ScopeGuards constructor.
+   */
+  ScopeGuardImplBase() : dismissed_(false) {}
+
+  /**
+   * @brief Dismiss function which allows to dismiss releasing of stored object.
+   */
+  void Dismiss() const { dismissed_ = true; }
+
+ protected:
+  /**
+   * @brief ScopeGuardImplBase the copy constructor
+   *
+   * @param other the object that should be copied.
+   */
+  ScopeGuardImplBase(const ScopeGuardImplBase& other)
+      : dismissed_(other.dismissed_) {
+    other.Dismiss();
+  }
+
+  /**
+   * Allows to safely execute release function(i.e. it will be called only
+   * in case of releasing wasn't dismiss.)
+   */
+  template <typename T>
+  void SafeExecute(T& t) {
+    if (!t.dismissed_) {
+      t.Execute();
+    }
+  }
+
+  ~ScopeGuardImplBase() {}
+
+  mutable bool dismissed_;
+
+ private:
+  // Disallow copying via assign operator.
+  ScopeGuardImplBase& operator=(const ScopeGuardImplBase&);
+};
+
+/**
+ * The class which allows to bind some parameter with free function.
+ * I.E.
+ * void release(char* p){delete p;}
+ *
+ * ScopeGuard guard = MakeGuard(release, p);
+ *
+ * So the parameter p will be passed to the specified function.
+ */
+template <typename Function, typename Parameter1>
+class ScopeGuardImpl1 : public ScopeGuardImplBase {
+ public:
+  /**
+   * @brief MakeGuard allows to create ScopeGuard object.
+   *
+   * @param fun function to call, when out of scope.
+   *
+   * @param p1 parameter which will be passed to the certain function.
+   *
+   * @return ScopeGuard object.
+   */
+  static ScopeGuardImpl1<Function, Parameter1> MakeGuard(Function fun,
+                                                         const Parameter1& p1) {
+    return ScopeGuardImpl1<Function, Parameter1>(fun, p1);
+  }
+
+  /**
+    Execute the SafeExecute function in destructor.
+   */
+  ~ScopeGuardImpl1() { SafeExecute(*this); }
+
+ protected:
+  /**
+   * @brief Execute allows to execute certain function with certain parameter.
+   */
+  void Execute() { fun_(p1_); }
+
+  /**
+   * @brief ScopeGuardImpl1 create ScopeGuard object.
+   *
+   * @param f function object.
+   *
+   * @param p1 parameter to to pass to the function object.
+   */
+  ScopeGuardImpl1(const Function& f, const Parameter1& p1) : fun_(f), p1_(p1) {}
+
+ private:
+  Function fun_;
+  const Parameter1 p1_;
+
+  friend class ScopeGuardImplBase;
+};
+
+/**
+ * The class which allows to call some member function in case of
+ * ScopeGuard object out of scope.
+ * I.E.
+ * vector<int> vec;
+ *
+ * // When function returns, the pop_back method for vector will be called.
+ * void foo() {
+ *   ScopeGuard guard = MakeObjGuard(vec, &vector::pop_back);
+ *   vec.push_back(5);
+ * }
+ */
+template <typename Obj, typename MemFun>
+class ObjScopeGuardImpl0 : public ScopeGuardImplBase {
+ public:
+  /**
+   * @brief MakeObjGuard creates ScopeGuard object.
+   *
+   * @param obj object whose method will be called.
+   *
+   * @param memFun the method to call.
+   *
+   * @return ScopeGuard object.
+   */
+  static ObjScopeGuardImpl0<Obj, MemFun> MakeObjGuard(Obj& obj, MemFun memFun) {
+    return ObjScopeGuardImpl0<Obj, MemFun>(obj, memFun);
+  }
+
+  /**
+    Execute the SafeExecute function in destructor.
+   */
+  ~ObjScopeGuardImpl0() { SafeExecute(*this); }
+
+ protected:
+  /**
+   * @brief Execute allows to execute certain function with certain parameter.
+   */
+  void Execute() { (obj_.*memFun_)(); }
+
+  /**
+   * @brief ObjScopeGuardImpl0 Create ScopeGuard object.
+   *
+   * @param obj object whose method will be called.
+   *
+   * @param memFun the method to call.
+   *
+   * @return ScopeGuard object.
+   */
+  ObjScopeGuardImpl0(Obj& obj, MemFun memFun) : obj_(obj), memFun_(memFun) {}
+
+ private:
+  Obj& obj_;
+  MemFun memFun_;
+  friend class ScopeGuardImplBase;
+};
+
+/**
+ * The class which allows to call some member function with certain parameter
+ * in case of ScopeGuard object out of scope.
+
+ */
+template <typename Obj, typename MemFun, typename Parameter1>
+class ObjScopeGuardImpl1 : public ScopeGuardImplBase {
+ public:
+  /**
+   * @brief MakeObjGuard creates ScopeGuard object.
+   *
+   * @param obj object whose method will be called.
+   *
+   * @param memFun the method to call.
+   *
+   * @param p1 the parameter to pass to the member function.
+   *
+   * @return ScopeGuard object.
+   */
+  static ObjScopeGuardImpl1<Obj, MemFun, Parameter1> MakeObjGuard(
+      Obj& obj, MemFun memFun, const Parameter1& p1) {
+    return ObjScopeGuardImpl1<Obj, MemFun, Parameter1>(obj, memFun, p1);
+  }
+
+  /**
+    Execute the SafeExecute function in destructor.
+   */
+  ~ObjScopeGuardImpl1() { SafeExecute(*this); }
+
+ protected:
+  /**
+   * @brief Execute allows to execute certain function with certain parameter.
+   */
+  void Execute() { (obj_.*memFun_)(p1_); }
+
+  /**
+   * @brief MakeObjGuard creates ScopeGuard object.
+   *
+   * @param obj object whose method will be called.
+   *
+   * @param memFun the method to call.
+   *
+   * @param p1 the parameter to pass to the member function.
+   *
+   * @return ScopeGuard object.
+   */
+  ObjScopeGuardImpl1(Obj& obj, MemFun memFun, const Parameter1& p1)
+      : obj_(obj), memFun_(memFun), p1_(p1) {}
+
+ private:
+  Obj& obj_;
+  MemFun memFun_;
+  const Parameter1 p1_;
+  friend class ScopeGuardImplBase;
+};
+
+typedef const ScopeGuardImplBase& ScopeGuard;
+
+template <typename T>
+void ArrayDeleter(const T value) {
+  delete[] value;
+}
+
+template <typename F, typename P1>
+ScopeGuardImpl1<F, P1> MakeGuard(F fun, P1 p1) {
+  return ScopeGuardImpl1<F, P1>::MakeGuard(fun, p1);
+}
+
+template <typename Obj, typename MemFun>
+ObjScopeGuardImpl0<Obj, MemFun> MakeObjGuard(Obj& obj, MemFun memFun) {
+  return ObjScopeGuardImpl0<Obj, MemFun>::MakeObjGuard(obj, memFun);
+}
+
+template <typename Obj, typename MemFun, typename P1>
+ObjScopeGuardImpl1<Obj, MemFun, P1> MakeObjGuard(Obj& obj, MemFun memFun,
+                                                 const P1& p1) {
+  return ObjScopeGuardImpl1<Obj, MemFun, P1>::MakeObjGuard(obj, memFun, p1);
+}
+}
+#endif  // SRC_COMPONENTS_INCLUDE_UTILS_SCOPE_GUARD_H

--- a/src/components/ivdcm_module/utils/types.h
+++ b/src/components/ivdcm_module/utils/types.h
@@ -1,0 +1,77 @@
+#ifndef SRC_FRAMEWORK_UTILS_TYPES_H_
+#define SRC_FRAMEWORK_UTILS_TYPES_H_
+
+#include <sys/types.h>
+
+/** @typedef Int8
+ *  @brief Definition for integral type with 8 bits
+ *
+ * Type Int8 has a sign. It can contain negative values.
+ * Range of Int8: -128..127
+ */
+typedef signed char Int8;
+
+/** @typedef UInt8
+ *  @brief Definition for integral type with 8 bits.
+ *
+ * Type UInt8 contains only positive values.
+ * Range of UInt8: 0..255
+ */
+typedef unsigned char UInt8;
+
+/** @typedef  Int16
+ *  @brief Definition for integral type with 16 bits
+ *
+ * Type Int16 has a sign. It can contain negative values.
+ * Range of Int16: -32,768..32,767
+ */
+typedef signed short Int16;
+
+/** @typedef  UInt16
+ *  @brief Definition for integral type with 16 bits
+ *
+ * Type UInt16 contains only positive values.
+ * Range of UInt16: 0..65,535
+ */
+typedef unsigned short UInt16;
+
+/** @typedef  WChar
+ *  @brief Definition for integral type with 32 bits
+ *
+ * This is a synonym for UInt32.
+ */
+typedef unsigned int WChar;
+
+/** @typedef  Int32
+ *  @brief Definition for integral type with 32 bits
+ *
+ * Type Int32 has a sign. It can contain negative values.
+ * Range of Int32: -2,147,483,648..2,147,483,647
+ */
+typedef signed int Int32;
+
+/** @typedef  UInt32
+ *  @brief Definition for integral type with 32 bits
+ *
+ * Type UInt32 contains only positive values.
+ * Range of UInt32: 0..4,294,967,295
+ */
+typedef unsigned int UInt32;
+
+/** @typedef  Int64
+ *  @brief Definition for integral type with 64 bits
+ *
+ * Type Int64 has a sign. It can contain negative values.
+ * Range of Int64: -9,223,372,036,854,775,808..9,223,372,036,854,775,807
+ */
+typedef signed long long int Int64;
+
+/** @typedef  UInt64
+ *  @brief Definition for integral type with 64 bits
+ *
+ * Type UInt64 contains only positive values.
+ * Range of UInt64: 0..18,446,744,073,709,551,615
+ */
+typedef unsigned long long int UInt64;
+
+#endif  // SRC_FRAMEWORK_UTILS_TYPES_H_


### PR DESCRIPTION
MessageBrocker was renamed to Transmitter in order to not to be confused with MessageBroker in SDL part.

@DKlimenko 
@VladSemenyuk 