### PR TITLE
REVSDL-2698, REVSDL-2699

### DIFF
--- a/src/components/can_cooperation/include/can_cooperation/can_module_constants.h
+++ b/src/components/can_cooperation/include/can_cooperation/can_module_constants.h
@@ -302,6 +302,11 @@ const char kFahrenheit[] = "FAHRENHEIT";
 const char kCelsius[]    = "CELSIUS";
 // TemperatureUnit enum
 
+// VentilationMode  enum
+const char kUpper[] = "UPPER";
+const char kLower[] = "LOWER";
+const char kBoth[] = "BOTH";
+// VentilationMode  enum
 
 // ButtonName enum
 const char kACMax[]       = "AC_MAX";

--- a/src/components/can_cooperation/include/can_cooperation/validators/struct_validators/climate_control_data_validator.h
+++ b/src/components/can_cooperation/include/can_cooperation/validators/struct_validators/climate_control_data_validator.h
@@ -75,6 +75,7 @@ class ClimateControlDataValidator : public Validator, public utils::Singleton<Cl
   ValidationScope defrost_zone_;
   ValidationScope dual_mode_enable_;
   ValidationScope ac_max_enable_;
+  ValidationScope ventilation_mode_;
 };
 
 }  // namespace valdiators

--- a/src/components/can_cooperation/include/can_cooperation/validators/validator.h
+++ b/src/components/can_cooperation/include/can_cooperation/validators/validator.h
@@ -78,7 +78,8 @@ enum EnumType {
   RADIO_BAND,
   RADIO_STATE,
   DEFROST_ZONE,
-  BUTTON_PRESS_MODE
+  BUTTON_PRESS_MODE,
+  VENTILATION_MODE
 };
 
 // validation_scope map with data that will be used for validation(minlength. maxlength, etc.)

--- a/src/components/can_cooperation/src/validators/struct_validators/climate_control_data_validator.cc
+++ b/src/components/can_cooperation/src/validators/struct_validators/climate_control_data_validator.cc
@@ -50,6 +50,7 @@ using message_params::kCirculateAirEnable;
 using message_params::kAutoModeEnable;
 using message_params::kDefrostZone;
 using message_params::kDualModeEnable;
+using message_params::kVentilationMode;
 
 ClimateControlDataValidator::ClimateControlDataValidator() {
   // name="fanSpeed"
@@ -85,6 +86,12 @@ ClimateControlDataValidator::ClimateControlDataValidator() {
   defrost_zone_[ValidationParams::ARRAY] = 0;
   defrost_zone_[ValidationParams::MANDATORY] = 0;
 
+  // name="ventilationMode"
+  ventilation_mode_[ValidationParams::TYPE] = ValueType::ENUM;
+  ventilation_mode_[ValidationParams::ENUM_TYPE] = EnumType::VENTILATION_MODE;
+  ventilation_mode_[ValidationParams::ARRAY] = 0;
+  ventilation_mode_[ValidationParams::MANDATORY] = 0;
+
   // name="dualModeEnable"
   dual_mode_enable_[ValidationParams::TYPE] = ValueType::BOOL;
   dual_mode_enable_[ValidationParams::ARRAY] = 0;
@@ -97,6 +104,7 @@ ClimateControlDataValidator::ClimateControlDataValidator() {
   validation_scope_map_[kAutoModeEnable] = &auto_mode_enable_;
   validation_scope_map_[kDefrostZone] = &defrost_zone_;
   validation_scope_map_[kDualModeEnable] = &dual_mode_enable_;
+  validation_scope_map_[kVentilationMode] = &ventilation_mode_;
 }
 
 ValidationResult ClimateControlDataValidator::Validate(const Json::Value& json,

--- a/src/components/can_cooperation/src/validators/struct_validators/temperature_validator.cc
+++ b/src/components/can_cooperation/src/validators/struct_validators/temperature_validator.cc
@@ -32,6 +32,7 @@
 
 #include "can_cooperation/validators/struct_validators/temperature_validator.h"
 #include "can_cooperation/can_module_constants.h"
+#include "can_cooperation/message_helper.h"
 
 namespace can_cooperation {
 
@@ -69,7 +70,7 @@ ValidationResult TemperatureValidator::Validate(const Json::Value& json,
 
   Json::Value desiredJson;
 
-  if (json.isMember(kUnit)) {
+  if (IsMember(json, kUnit)) {
     if (enums_value::kFahrenheit == json[kUnit].asString()) {
       if (!json.isMember(kValueF)) {
         LOG4CXX_ERROR(logger_, "Param " <<kValueF <<" is missed!");

--- a/src/components/can_cooperation/src/validators/validator.cc
+++ b/src/components/can_cooperation/src/validators/validator.cc
@@ -239,6 +239,14 @@ ValidationResult Validator::ValidateEnumValue(const std::string& value,
       return ValidationResult::INVALID_DATA;
     }
   } else if (validation_scope[ValidationParams::ENUM_TYPE] ==
+        EnumType::VENTILATION_MODE) {
+      if (value != enums_value::kUpper &&
+          value != enums_value::kLower &&
+          value != enums_value::kBoth) {
+        LOG4CXX_ERROR(logger_, "Wrong VentilationMode enum value!");
+        return ValidationResult::INVALID_DATA;
+      }
+  } else if (validation_scope[ValidationParams::ENUM_TYPE] ==
       EnumType::BUTTON_NAME) {
     if (value != enums_value::kACMax       &&
         value != enums_value::kAC          &&


### PR DESCRIPTION
[SDL_RC_B4.1] [Mobile Validation] - Core dumped when app sending SetInteriorVehicleData RPC with currentTemp wrong type
REVSDL-2699
[SDL_RC_B4.1] [Mobile Validation] - RSDL doesn't send parameters: "currentTemp", "ventilationMode" to HMI when app sending SetInteriorVehicleData RPC