### PR TITLE
Fix request controller

### DIFF
--- a/src/components/can_cooperation/include/can_cooperation/request_controller.h
+++ b/src/components/can_cooperation/include/can_cooperation/request_controller.h
@@ -34,6 +34,7 @@
 #define SRC_COMPONENTS_CAN_COOPERATION_INCLUDE_CAN_COOPERATION_REQUEST_CONTROLLER_H_
 
 #include <map>
+#include <utility>
 
 #include "can_cooperation/commands/command.h"
 #include "can_cooperation/can_module_timer.h"
@@ -42,7 +43,10 @@ namespace can_cooperation {
 namespace request_controller {
 
 typedef utils::SharedPtr<commands::Command> MobileRequestPtr;
-typedef uint32_t  correlation_id;
+typedef int32_t ConnectionKey;
+typedef int32_t CorrelationId;
+typedef std::pair<ConnectionKey, CorrelationId> RequestId;
+typedef std::map<RequestId, MobileRequestPtr> MobileRequestsList;
 
 /**
  * @brief RequestController class is used to manage mobile requests lifetime.
@@ -63,22 +67,22 @@ class RequestController : public functional_modules::TimerObserver<TrackableMess
 
   /**
    * @brief Adds pointer to request.
-   * @param mobile_correlation_id mobile request correlation id
+   * @param unique id of request
    * @param command pointer to request created in mobile factory
+   * @return true if request is registered
    */
-  void AddRequest(const uint32_t& mobile_correlation_id,
-                  MobileRequestPtr request);
+  bool AddRequest(const RequestId& uid, MobileRequestPtr request);
 
   /**
    * @brief Removes request
-   * @param mobile_corellation_id mobile request correlation id
+   * @param unique id of request
    */
-  void DeleteRequest(const uint32_t& mobile_correlation_id);
+  void DeleteRequest(const RequestId& uid);
 
   void OnTimeoutTriggered(const TrackableMessage& expired);
 
  private:
-  std::map<correlation_id, MobileRequestPtr> mobile_request_list_;
+  MobileRequestsList mobile_request_list_;
   functional_modules::ModuleTimer<TrackableMessage> timer_;
   DISALLOW_COPY_AND_ASSIGN(RequestController);
 };

--- a/src/components/can_cooperation/test/src/can_module_test.cc
+++ b/src/components/can_cooperation/test/src/can_module_test.cc
@@ -135,6 +135,8 @@ TEST_F(CanModuleTest, ProcessMessagePass) {
   application_manager::MessagePtr message = new application_manager::Message(
     protocol_handler::MessagePriority::FromServiceType(
       protocol_handler::ServiceType::kRpc));
+  message->set_connection_key(1);
+  message->set_correlation_id(1);
   message->set_function_id(MobileFunctionID::ON_INTERIOR_VEHICLE_DATA);
 
   std::string json = "{\"jsonrpc\": \"2.0\", \"method\": \"RC.OnInteriorVehicleData\",\


### PR DESCRIPTION
- Add using connection_key to identify request
- If unique identificator is already registered, new request with the same id wil not be run