### PR TITLE
Add header-only pthread lib for android

### DIFF
--- a/app/src/main/cpp/src/components/include/utils/threads/pt-internal.h
+++ b/app/src/main/cpp/src/components/include/utils/threads/pt-internal.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2008 The Android Open Source Project
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+#ifndef _PTHREAD_INTERNAL_H_
+#define _PTHREAD_INTERNAL_H_
+
+#include <pthread.h>
+
+struct pthread_internal_t {
+  struct pthread_internal_t* next;
+  struct pthread_internal_t* prev;
+
+  pid_t tid;
+
+  void** tls;
+
+  volatile pthread_attr_t attr;
+
+  __pthread_cleanup_t* cleanup_stack;
+
+  void* (*start_routine)(void*);
+  void* start_routine_arg;
+  void* return_value;
+
+  void* alternate_signal_stack;
+
+  /*
+   * The dynamic linker implements dlerror(3), which makes it hard for us to implement this
+   * per-thread buffer by simply using malloc(3) and free(3).
+   */
+#define __BIONIC_DLERROR_BUFFER_SIZE 508
+  char dlerror_buffer[__BIONIC_DLERROR_BUFFER_SIZE];
+	
+	//  ugly hack: use last 4 bytes of dlerror_buffer as cancel_lock
+	pthread_mutex_t cancel_lock; 
+};
+
+/* Has the thread a cancellation request? */
+#define PTHREAD_ATTR_FLAG_CANCEL_PENDING 0x00000008
+
+/* Has the thread enabled cancellation? */
+#define PTHREAD_ATTR_FLAG_CANCEL_ENABLE 0x00000010
+
+/* Has the thread asyncronous cancellation? */
+#define PTHREAD_ATTR_FLAG_CANCEL_ASYNCRONOUS 0x00000020
+
+/* Has the thread a cancellation handler? */
+#define PTHREAD_ATTR_FLAG_CANCEL_HANDLER 0x00000040
+
+struct pthread_internal_t *__pthread_getid ( pthread_t );
+
+int __pthread_do_cancel (struct pthread_internal_t *);
+
+void pthread_init(void);
+
+#endif /* _PTHREAD_INTERNAL_H_ */

--- a/app/src/main/cpp/src/components/include/utils/threads/pthread_android.h
+++ b/app/src/main/cpp/src/components/include/utils/threads/pthread_android.h
@@ -129,13 +129,8 @@ inline int pthread_cancel(pthread_t t) {
             return 0;
         }
 
-        if (p->attr.flags & PTHREAD_ATTR_FLAG_CANCEL_ASYNCRONOUS) {
-            pthread_mutex_unlock(&p->cancel_lock);
-            err = __pthread_do_cancel(p);
-        } else {
-            // DEFERRED CANCEL NOT IMPLEMENTED YET
-            pthread_mutex_unlock(&p->cancel_lock);
-        }
+        pthread_mutex_unlock(&p->cancel_lock);
+        err = __pthread_do_cancel(p);
 
         return err;
     }

--- a/app/src/main/cpp/src/components/include/utils/threads/pthread_android.h
+++ b/app/src/main/cpp/src/components/include/utils/threads/pthread_android.h
@@ -1,0 +1,142 @@
+/* Copyright (C) 2002 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Library General Public License as
+   published by the Free Software Foundation; either version 2 of the
+   License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Library General Public License for more details.
+
+   You should have received a copy of the GNU Library General Public
+   License along with the GNU C Library; see the file COPYING.LIB.  If not,
+   write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+   Boston, MA 02111-1307, USA.  */
+
+#ifndef SRC_COMPONENTS_INCLUDE_UTILS_THREADS_PTHREAD_ANDROID_H
+#define SRC_COMPONENTS_INCLUDE_UTILS_THREADS_PTHREAD_ANDROID_H
+#include "pt-internal.h"
+
+#define PTHREAD_CANCELED ((void *) -1)
+#define PTHREAD_CANCEL_ENABLE 0x00000010
+#define PTHREAD_CANCEL_DISABLE 0x00000000
+
+inline void pthread_cancel_handler(int signum) {
+        pthread_exit(0);
+    }
+
+inline void pthread_init() {
+        struct sigaction sa;
+        struct pthread_internal_t *p = (struct pthread_internal_t *) pthread_self();
+
+        if (p->attr.flags & PTHREAD_ATTR_FLAG_CANCEL_HANDLER)
+            return;
+
+        // set thread status as pthread_create should do.
+        // ASYNCROUNOUS is not set, see pthread_setcancelstate(3)
+        p->attr.flags |= PTHREAD_ATTR_FLAG_CANCEL_HANDLER | PTHREAD_ATTR_FLAG_CANCEL_ENABLE;
+
+        sa.sa_handler = pthread_cancel_handler;
+        sigemptyset(&(sa.sa_mask));
+        sa.sa_flags = 0;
+
+        sigaction(SIGRTMIN, &sa, NULL);
+    }
+
+inline static void call_exit() {
+        pthread_exit(0);
+    }
+
+inline int __pthread_do_cancel(struct pthread_internal_t *p) {
+
+        if (p == (struct pthread_internal_t *) pthread_self())
+            call_exit();
+        else if (p->attr.flags & PTHREAD_ATTR_FLAG_CANCEL_HANDLER)
+            pthread_kill((pthread_t) p, SIGRTMIN);
+        else
+            pthread_kill((pthread_t) p, SIGTERM);
+
+        return 0;
+    }
+
+inline void pthread_testcancel() {
+        struct pthread_internal_t *p = (struct pthread_internal_t *) pthread_self();
+        int cancelled;
+
+        pthread_init();
+
+        pthread_mutex_lock(&p->cancel_lock);
+        cancelled = (p->attr.flags & PTHREAD_ATTR_FLAG_CANCEL_ENABLE) &&
+                    (p->attr.flags & PTHREAD_ATTR_FLAG_CANCEL_PENDING);
+        pthread_mutex_unlock(&p->cancel_lock);
+
+        if (cancelled)
+            pthread_exit(PTHREAD_CANCELED);
+    }
+
+inline int pthread_setcancelstate(int state, int *oldstate) {
+        struct pthread_internal_t *p = (struct pthread_internal_t *) pthread_self();
+        int newflags;
+
+        pthread_init();
+
+        switch (state) {
+            default:
+                return EINVAL;
+            case PTHREAD_CANCEL_ENABLE:
+            case PTHREAD_CANCEL_DISABLE:
+                break;
+        }
+
+        pthread_mutex_lock(&p->cancel_lock);
+        if (oldstate)
+            *oldstate = p->attr.flags & PTHREAD_ATTR_FLAG_CANCEL_ENABLE;
+
+        if (state == PTHREAD_ATTR_FLAG_CANCEL_ENABLE)
+            p->attr.flags |= PTHREAD_ATTR_FLAG_CANCEL_ENABLE;
+        else
+            p->attr.flags &= ~PTHREAD_ATTR_FLAG_CANCEL_ENABLE;
+        newflags = p->attr.flags;
+        pthread_mutex_unlock(&p->cancel_lock);
+
+        if ((newflags & PTHREAD_ATTR_FLAG_CANCEL_PENDING) &&
+            (newflags & PTHREAD_ATTR_FLAG_CANCEL_ENABLE) &&
+            (newflags & PTHREAD_ATTR_FLAG_CANCEL_ASYNCRONOUS))
+            __pthread_do_cancel(p);
+
+        return 0;
+    }
+
+inline int pthread_cancel(pthread_t t) {
+        int err = 0;
+        struct pthread_internal_t *p = (struct pthread_internal_t *) t;
+
+        pthread_init();
+
+        pthread_mutex_lock(&p->cancel_lock);
+        if (p->attr.flags & PTHREAD_ATTR_FLAG_CANCEL_PENDING) {
+            pthread_mutex_unlock(&p->cancel_lock);
+            return 0;
+        }
+
+        p->attr.flags |= PTHREAD_ATTR_FLAG_CANCEL_PENDING;
+
+        if (!(p->attr.flags & PTHREAD_ATTR_FLAG_CANCEL_ENABLE)) {
+            pthread_mutex_unlock(&p->cancel_lock);
+            return 0;
+        }
+
+        if (p->attr.flags & PTHREAD_ATTR_FLAG_CANCEL_ASYNCRONOUS) {
+            pthread_mutex_unlock(&p->cancel_lock);
+            err = __pthread_do_cancel(p);
+        } else {
+            // DEFERRED CANCEL NOT IMPLEMENTED YET
+            pthread_mutex_unlock(&p->cancel_lock);
+        }
+
+        return err;
+    }
+#endif //SRC_COMPONENTS_INCLUDE_UTILS_THREADS_PTHREAD_ANDROID_H

--- a/app/src/main/cpp/src/components/include/utils/threads/thread.h
+++ b/app/src/main/cpp/src/components/include/utils/threads/thread.h
@@ -54,32 +54,6 @@ typedef pthread_t PlatformThreadHandle;
 #error Please implement thread for your OS
 #endif
 
-#if defined(__ANDROID__)
-#define SIG_CANCEL_SIGNAL SIGUSR1
-#define PTHREAD_CANCEL_ENABLE 1
-#define PTHREAD_CANCEL_DISABLE 0
-
-typedef long pthread_t;
-
-static int pthread_setcancelstate(int state, int *oldstate) {
-    sigset_t   new_sig, old_sig;
-    int ret;
-    sigemptyset (&new_sig);
-    sigaddset (&new_sig, SIG_CANCEL_SIGNAL);
-
-    ret = pthread_sigmask(state == PTHREAD_CANCEL_ENABLE ? SIG_BLOCK : SIG_UNBLOCK, &new_sig , &old_sig);
-    if(oldstate != NULL)
-    {
-        *oldstate =sigismember(&old_sig,SIG_CANCEL_SIGNAL) == 0 ? PTHREAD_CANCEL_DISABLE : PTHREAD_CANCEL_ENABLE;
-    }
-    return ret;
-}
-
-static inline int pthread_cancel(pthread_t thread) {
-    return pthread_kill(thread, SIGINT);
-}
-#endif
-
 /**
  * @brief Non platform specific thread abstraction that establishes a
  * threads::ThreadDelegate on a new thread.

--- a/app/src/main/cpp/src/components/utils/src/threads/thread_delegate.cc
+++ b/app/src/main/cpp/src/components/utils/src/threads/thread_delegate.cc
@@ -37,6 +37,10 @@
 #include "utils/lock.h"
 #include "utils/threads/thread.h"
 
+#ifdef __ANDROID__
+#include "utils/threads/pthread_android.h"
+#endif // __ANDROID__
+
 namespace threads {
 
 ThreadDelegate::~ThreadDelegate() {

--- a/app/src/main/cpp/src/components/utils/src/threads/thread_posix.cc
+++ b/app/src/main/cpp/src/components/utils/src/threads/thread_posix.cc
@@ -43,6 +43,10 @@
 #include "utils/threads/thread.h"
 #include "utils/threads/thread_delegate.h"
 
+#ifdef __ANDROID__
+#include "utils/threads/pthread_android.h"
+#endif // __ANDROID__
+
 #ifndef __QNXNTO__
 const int EOK = 0;
 #endif
@@ -71,7 +75,7 @@ void* Thread::threadFunc(void* arg) {
   auto thread_procedure_execution = [](Thread* thread) {
     thread->thread_state_ = kThreadStateRunning;
     pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
-//    pthread_testcancel();
+    pthread_testcancel();
     thread->state_lock_.Release();
     thread->delegate_->threadMain();
     thread->state_lock_.Acquire();


### PR DESCRIPTION
This PR contains header-only library with Android-specific implementation of several functions from pthreads lib.