### PR TITLE
Dynamic Load Plugin for Arch

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -69,6 +69,17 @@ android {
             }
 
             def obj_build_folder =  "${project.getBuildDir()}/intermediates/cmake/debug/obj"
+            println "obj build dir: {$obj_build_folder}"
+
+
+            def obj_plugin_folder =  "${project.getProjectDir()}/.cxx/cmake/debug/%ARCH%/src/appMain"
+            println "proj plugin dir: {$obj_plugin_folder}"
+
+
+            def obj_jni_folder =  "${project.android.sourceSets.main.jniLibs.getSrcDirs()[0].path}"
+
+            println "jni so dir: {$obj_jni_folder}"
+
             def archs = []
             fileTree("${obj_build_folder}").visit { FileVisitDetails details ->
                 if (details.isDirectory()) {
@@ -80,15 +91,25 @@ android {
                 println "Prepare libraries for ${it}"
 
                 def sdl_so_folder = "${obj_build_folder}/${it}"
+                def target_jni_folder = "${obj_jni_folder}/${it}"
                 println "Output libs: ${sdl_so_folder}"
 
                 def target_cpp_lib_file = cpp_lib_file.replace("%ARCH%", it)
-                
+                def target_cpp_plugin_lib_file = obj_plugin_folder.replace("%ARCH%", it)
+
                 println "Copying C++ library from ${target_cpp_lib_file}"
                 copy {
                     from "${target_cpp_lib_file}"
                     into "${sdl_so_folder}"
                 }
+
+                println "Copying C++ plugin library from ${target_cpp_plugin_lib_file}"
+                copy {
+                    from "${target_cpp_plugin_lib_file}"
+                    into "${target_jni_folder}"
+                    include "*.so"
+                }
+
 
                 def third_party_arch = "${third_party_libs}/${it}/lib"
                 println "Copying 3rd party libs..."

--- a/app/src/main/cpp/src/components/application_manager/src/policies/policy_handler.cc
+++ b/app/src/main/cpp/src/components/application_manager/src/policies/policy_handler.cc
@@ -334,11 +334,12 @@ bool PolicyHandler::LoadPolicyLibrary() {
     ExchangePolicyManager(nullptr);
     sync_primitives::AutoWriteLock lock(policy_manager_lock_);
 
-#ifdef __ANDROID__
+/*#ifdef __ANDROID__
     const std::string policy_lib_path = application_manager_.get_settings().plugins_folder() + "/" + kLibrary;
 #else
     const std::string policy_lib_path = kLibrary;
-#endif
+#endif*/
+    const std::string policy_lib_path = kLibrary;
 
     void* const dl_policy_handle = dlopen(policy_lib_path.c_str(), RTLD_LAZY);
 

--- a/app/src/main/java/org/luxoft/sdl_core/MainActivity.java
+++ b/app/src/main/java/org/luxoft/sdl_core/MainActivity.java
@@ -27,7 +27,9 @@ public class MainActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        sdl_cache_folder_path = getCacheDir().toString();
+        //for now use the external sd card for the storage directory so that sharpHMI can access the grapchis and other files
+        //the user will need to manually go to the app settings after installed on the device and enable read/write permission to external storage
+        sdl_cache_folder_path = Environment.getExternalStorageDirectory().toString().concat("/SDL");//getCacheDir().toString();
         TextView cache_folder_view = findViewById(R.id.cache_folder);
         cache_folder_view.setText(String.format("Cache folder: %s", sdl_cache_folder_path));
 


### PR DESCRIPTION
Update build.gradle task to copy plugins into jniLibs folder. Android studio will automatically package so files for each arch from jniLibs folder allowing us to load the plugin without the path included. Also updated storage directory to use the external sd card so that other apps can access it (like the HMI for accessing graphics). The user will need to manually enable access to the storage directory via the android settings so that sdl core has read / write access. At a later time we can add a check at start of the app requesting the user to grant access to the storage directory which will eliminate the need to go to the settings and manually enable.