### PR TITLE
Wait for a complete timer delegate thread stop

### DIFF
--- a/app/src/main/cpp/src/components/utils/src/timer.cc
+++ b/app/src/main/cpp/src/components/utils/src/timer.cc
@@ -148,7 +148,12 @@ void timer::Timer::StopThread() {
     delegate_->set_finalized_flag(true);
     {
       sync_primitives::AutoUnlock auto_unlock(state_lock_);
+#ifdef __ANDROID__
+      // Wait for a full thread stopping to avoid data races in Android threads
+      thread_->Stop(threads::Thread::kThreadSoftStop);
+#else
       thread_->Stop(threads::Thread::kThreadStopDelegate);
+#endif // __ANDROID__
     }
     delegate_->set_finalized_flag(false);
   }


### PR DESCRIPTION
In some cases when timer just stops delegate thread without waiting for it's complete finishing, there might be some unexpected data races which can be avoided if thread is finished completely, especially if it is going to be restarted like in a periodic timers. By that reason, thread stopping priority should be increased to soft stop.