### PR TITLE
fix build with external_proprietary policy

### DIFF
--- a/app/src/main/cpp/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/app/src/main/cpp/src/components/application_manager/src/message_helper/message_helper.cc
@@ -2280,7 +2280,7 @@ void MessageHelper::SendGetListOfPermissionsResponse(
 
   SmartObject& params = (*message)[strings::params];
 
-  params[strings::function_id] = FunctionID::SDL_GetListOfPermissions;
+  params[strings::function_id] = hmi_apis::FunctionID::SDL_GetListOfPermissions;
   params[strings::message_type] = MessageType::kResponse;
   params[strings::correlation_id] = correlation_id;
   params[hmi_response::code] = static_cast<int32_t>(Common_Result::SUCCESS);

--- a/app/src/main/cpp/src/components/policy/policy_external/CMakeLists.txt
+++ b/app/src/main/cpp/src/components/policy/policy_external/CMakeLists.txt
@@ -131,7 +131,7 @@ target_link_libraries(PolicyStatic ${LIBRARIES})
 add_library(Policy SHARED "src/policy_manager_impl.cc")
 target_link_libraries(Policy PolicyStatic)
 
-if (ENABLE_LOG)
+if(ENABLE_LOG AND NOT ANDROID)
   target_link_libraries(Policy log4cxx -L${LOG4CXX_LIBS_DIRECTORY})
 endif()
 


### PR DESCRIPTION
Some fixes that make it possible to build project for Android archs with cmake option:
EXTENDED_POLICY  =  EXTERNAL_PROPRIETARY