### PR TITLE
tuning policy_manager for android environment

### DIFF
--- a/app/src/main/cpp/src/appMain/sample_policy_manager.py
+++ b/app/src/main/cpp/src/appMain/sample_policy_manager.py
@@ -22,6 +22,8 @@ parser.add_argument("--add_http_header", action="store_true",
                     help="Enter this parameter to add HTTP heaer on packing policy table")
 parser.add_argument("--encryption", action="store_true",
                     help="Encrypt policy table")
+parser.add_argument("--android", action="store_true",
+                    help="SDL Core is runing on android device")
 
 
 def http_header(data):
@@ -50,8 +52,12 @@ def decrypt(data):
     return data
 
 
-def pack(data, encryption, add_http_header):
+def pack(data, encryption, add_http_header, android):
     file_path = data['fileName']
+
+    if android:
+        path = "/tmp/sdl_snapshot.json"
+
     file_ptr = open(file_path, "r+")
 
     request_type = data['requestType']
@@ -70,8 +76,12 @@ def pack(data, encryption, add_http_header):
     return file_path
 
 
-def unpack(data, encryption):
+def unpack(data, encryption, android):
     file_path = data['fileName']
+
+    if android:
+        path = "/tmp/sdl_snapshot.json"
+
     file_ptr = open(file_path, 'r+')
 
     request_type = data['requestType']
@@ -167,11 +177,11 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    pack_application = tornado.web.Application([(r'/', WebSocketHandler, dict(encryption=args.encryption, add_http_header=args.add_http_header, 
-        handle_func = lambda data, encryption, add_http_header: pack(data, encryption, add_http_header)))])
+    pack_application = tornado.web.Application([(r'/', WebSocketHandler, dict(encryption=args.encryption, add_http_header=args.add_http_header,
+        handle_func = lambda data, encryption, add_http_header, android: pack(data, encryption, add_http_header, args.android)))])
 
     unpack_application = tornado.web.Application([(r'/', WebSocketHandler, dict(encryption=args.encryption, add_http_header=None,
-        handle_func = lambda data, encryption, add_http_header: unpack(data, encryption)))])
+        handle_func = lambda data, encryption, add_http_header, android: unpack(data, encryption, args.android)))])
 
     pack_server = tornado.httpserver.HTTPServer(pack_application)
     unpack_server = tornado.httpserver.HTTPServer(unpack_application)

--- a/app/src/main/cpp/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_received_policy_update.cc
+++ b/app/src/main/cpp/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_received_policy_update.cc
@@ -63,11 +63,19 @@ void OnReceivedPolicyUpdate::Run() {
   const std::string& file_path =
       (*message_)[strings::msg_params][hmi_notification::policyfile].asString();
   policy::BinaryMessage file_content;
-  if (!file_system::ReadBinaryFile(file_path, file_content)) {
+
+  std::string file_name = file_path;
+
+#ifdef __ANDROID__
+  const std::string t_name = file_path.substr(file_path.find_last_of("/\\") + 1);
+  file_name = "/data/user/0/org.luxoft.sdl_core/cache/ivsu_cache/" + t_name;
+#endif
+
+  if (!file_system::ReadBinaryFile(file_name, file_content)) {
     SDL_LOG_ERROR("Failed to read Update file.");
     return;
   }
-  policy_handler_.ReceiveMessageFromSDK(file_path, file_content);
+  policy_handler_.ReceiveMessageFromSDK(file_name, file_content);
 #else
   SDL_LOG_WARN(
       "This RPC is part of extended policy flow. "

--- a/app/src/main/cpp/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_received_policy_update.cc
+++ b/app/src/main/cpp/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_received_policy_update.cc
@@ -68,7 +68,8 @@ void OnReceivedPolicyUpdate::Run() {
 
 #ifdef __ANDROID__
   const std::string t_name = file_path.substr(file_path.find_last_of("/\\") + 1);
-  file_name = "/data/user/0/org.luxoft.sdl_core/cache/ivsu_cache/" + t_name;
+  const std::string system_folder = application_manager_.get_settings().system_files_path();
+  file_name = system_folder + "/" + t_name;
 #endif
 
   if (!file_system::ReadBinaryFile(file_name, file_content)) {

--- a/app/src/main/cpp/src/components/policy/policy_external/CMakeLists.txt
+++ b/app/src/main/cpp/src/components/policy/policy_external/CMakeLists.txt
@@ -112,6 +112,8 @@ set(LIBRARIES
   Utils
 )
 
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
 if (CMAKE_SYSTEM_NAME STREQUAL "QNX")
   # --- QDB Wrapper
   include_directories (${COMPONENTS_DIR}/utils/include/utils)
@@ -135,7 +137,7 @@ if(ENABLE_LOG AND NOT ANDROID)
   target_link_libraries(Policy log4cxx -L${LOG4CXX_LIBS_DIRECTORY})
 endif()
 
-add_custom_target(copy_library_Policy ALL
+add_custom_target(copy_policy_library ALL
   COMMAND ${CMAKE_COMMAND} -E copy_if_different
     ${CMAKE_CURRENT_BINARY_DIR}/${library_name}
     ${copy_destination}


### PR DESCRIPTION
Added the ability to set "--android" argument for sample_policy_manager.py script in case when sdl core is running on android device (emulator).
Also adapted  sdl_rpc_plugin for Android to read PT file from internal storage. 