### PR TITLE
Change app storage and icons folder to external SD card

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -158,6 +158,7 @@ dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
+    implementation 'androidx.documentfile:documentfile:1.0.1'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'

--- a/app/src/main/cpp/src/appMain/androidSmartDeviceLink.ini
+++ b/app/src/main/cpp/src/appMain/androidSmartDeviceLink.ini
@@ -34,13 +34,13 @@ SDLVersion = {GIT_COMMIT}
 LogsEnabled = true
 ; Contains .json/.ini files
 ; Default value is SDL working directory
-AppConfigFolder = %ANDROID_EXTERNAL_DIR%
+AppConfigFolder = %ANDROID_INTERNAL_DIR%/files
 ; Contains SDL configuration files - .json/.ini
 ; Default value is SDL working directory
-AppStorageFolder = %ANDROID_INTERNAL_DIR%
+AppStorageFolder = %ANDROID_EXTERNAL_DIR%
 ; Contains resourses, e.g. audio8bit.wav
 ; Default value is SDL working directory
-AppResourceFolder = %ANDROID_EXTERNAL_DIR%
+AppResourceFolder = %ANDROID_INTERNAL_DIR%/files
 ; Standard min stack size
 ;     in Ubuntu : PTHREAD_STACK_MIN = 16384
 ;     in QNX : PTHREAD_STACK_MIN = 256
@@ -52,7 +52,7 @@ MixingAudioSupported = true
 ; In case HMI doesn’t send some capabilities to SDL, the values from the file are used by SDL
 HMICapabilities = hmi_capabilities.json
 ; Path to file containing cached response for UI.GetCapabilities/GetSupportedLanguages
-HMICapabilitiesCacheFile = hmi_capabilities_cache.json
+HMICapabilitiesCacheFile = %ANDROID_INTERNAL_DIR%/cache/hmi_capabilities_cache.json
 ; Maximum cmdId of VR command which may be registered on SDL
 ; Bigger value used for system VR commands processing by SDL
 MaxCmdID = 2000000000
@@ -79,7 +79,7 @@ HeartBeatTimeout = 7000
 SupportedDiagModes = 0x01, 0x02, 0x03, 0x05, 0x06, 0x07, 0x09, 0x0A, 0x18, 0x19, 0x22, 0x3E
 ; The path to the system file directory for inter-operation between SDL and System (e.g. IVSU files and others).
 ; If parameter is empty, SDL uses /tmp/fs/mp/images/ivsu_cache by default
-SystemFilesPath = %ANDROID_INTERNAL_DIR%/ivsu_cache
+SystemFilesPath = %ANDROID_INTERNAL_DIR%/cache/ivsu_cache
 ; To restore the last transport state (name, applications or channels) on SDL on a new device connection and on disconnect
 UseLastState = true
 ; Port to obtain the performance information about messages processing
@@ -90,7 +90,7 @@ ReadDIDRequest = 5, 1
 GetVehicleDataRequest = 5, 1
 ; Limitation for a number of GetInteriorVehicleDataRequest requests (the 1st value) per (the 2nd value) seconds
 GetInteriorVehicleDataRequest = 5, 1
-PluginFolder = %ANDROID_EXTERNAL_DIR%
+PluginFolder = %ANDROID_INTERNAL_DIR%/files
 
 ; The time used during switch transport procedure
 AppTransportChangeTimer = 500
@@ -159,14 +159,14 @@ HelpCommand = Help
 
 [AppInfo]
 ; The path for applications info storage.
-AppInfoStorage = %ANDROID_INTERNAL_DIR%/app_info.dat
+AppInfoStorage = %ANDROID_INTERNAL_DIR%/cache/app_info.dat
 
 [Security Manager]
 ;Protocol = TLSv1.2
 Protocol = DTLSv1.0
 ; Certificate and key path to pem file
-CertificatePath = %ANDROID_EXTERNAL_DIR%/security/mycert.pem
-KeyPath         = %ANDROID_EXTERNAL_DIR%/security/mykey.pem
+CertificatePath = %ANDROID_INTERNAL_DIR%/files/security/mycert.pem
+KeyPath         = %ANDROID_INTERNAL_DIR%/files/security/mykey.pem
 ; SSL mode could be SERVER or CLIENT
 SSLMode         = CLIENT
 ; Could be ALL ciphers or list of chosen
@@ -175,7 +175,7 @@ CipherList      = ALL
 ; Verify Mobile app certificate (could be used in both SSLMode Server and Client)
 VerifyPeer  = true
 ; Preloaded CA certificates directory
-CACertificatePath = %ANDROID_EXTERNAL_DIR%/security
+CACertificatePath = %ANDROID_INTERNAL_DIR%/files/security
 ; Services which can not be started unprotected (could be id's from 0x01 to 0xFF)
 ;ForceProtectedService = 0x0A, 0x0B
 ForceProtectedService = Non
@@ -266,7 +266,7 @@ HashStringSize = 32
 [SDL4]
 ; Section for features added in protocol version 4
 ; Path where apps icons must be stored
-AppIconsFolder = %ANDROID_INTERNAL_DIR%
+AppIconsFolder = %ANDROID_EXTERNAL_DIR%
 ; Max size of the folder in bytes
 AppIconsFolderMaxSize = 104857600
 ; Amount of oldest icons to remove in case of max folder size was reached

--- a/app/src/main/cpp/src/appMain/android_platform_interface.cc
+++ b/app/src/main/cpp/src/appMain/android_platform_interface.cc
@@ -69,8 +69,8 @@ void StartSDL(JNIEnv* env, jobject)
 
 
     std::string ini_name = "androidSmartDeviceLink.ini";
-	if (!external_storage.empty()) {
-	    ini_name = external_storage + "/" + ini_name;
+	if (!internal_storage.empty()) {
+	    ini_name = internal_storage + "/files/" + ini_name;
 	}
 
     profile_instance.set_config_file_name(ini_name);

--- a/app/src/main/cpp/src/components/config_profile/src/profile.cc
+++ b/app/src/main/cpp/src/components/config_profile/src/profile.cc
@@ -1345,7 +1345,7 @@ void Profile::UpdateValues() {
                   kMainSection,
                   kHmiCapabilitiesCacheFileKey);
 
-  if (!hmi_capabilities_cache_file_name_.empty()) {
+  if (!hmi_capabilities_cache_file_name_.empty() && IsRelativePath(hmi_capabilities_cache_file_name_)) {
     hmi_capabilities_cache_file_name_ =
         app_storage_folder_ + "/" + hmi_capabilities_cache_file_name_;
   }

--- a/app/src/main/cpp/src/components/policy/policy_external/src/sql_pt_representation.cc
+++ b/app/src/main/cpp/src/components/policy/policy_external/src/sql_pt_representation.cc
@@ -322,7 +322,12 @@ InitResult SQLPTRepresentation::Init(const PolicySettings* settings) {
 #endif  // BUILD_TESTS
 #ifndef __QNX__
   if (!is_in_memory) {
-    const std::string& path = get_settings().app_storage_folder();
+#ifdef __ANDROID__
+    std::string path = get_settings().system_files_path();
+    path = path.substr(0, path.find_last_of("/"));
+#else
+    const std::string path = get_settings().app_storage_folder();
+#endif
     if (!path.empty()) {
       db_->set_path(path + "/");
     }

--- a/app/src/main/cpp/src/components/policy/policy_regular/src/sql_pt_representation.cc
+++ b/app/src/main/cpp/src/components/policy/policy_regular/src/sql_pt_representation.cc
@@ -307,7 +307,12 @@ InitResult SQLPTRepresentation::Init(const PolicySettings* settings) {
 #endif  // BUILD_TESTS
 
   if (!is_in_memory) {
-    const std::string& path = get_settings().app_storage_folder();
+#ifdef __ANDROID__
+    std::string path = get_settings().system_files_path();
+    path = path.substr(0, path.find_last_of("/"));
+#else
+    const std::string path = get_settings().app_storage_folder();
+#endif
     if (!path.empty()) {
       db_->set_path(path + "/");
     }

--- a/app/src/main/java/org/luxoft/sdl_core/FileUtil.java
+++ b/app/src/main/java/org/luxoft/sdl_core/FileUtil.java
@@ -1,0 +1,121 @@
+package org.luxoft.sdl_core;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.net.Uri;
+import android.os.Build;
+import android.os.storage.StorageManager;
+import android.os.storage.StorageVolume;
+import android.provider.DocumentsContract;
+
+import androidx.annotation.Nullable;
+
+import java.io.File;
+import java.lang.reflect.Array;
+import java.lang.reflect.Method;
+import java.util.List;
+
+public class FileUtil {
+    private static final String PRIMARY_VOLUME_NAME = "primary";
+
+    @Nullable
+    public static String getFullPathFromTreeUri(@Nullable final Uri treeUri, Context con) {
+        if (treeUri == null) return null;
+        String volumePath = getVolumePath(getVolumeIdFromTreeUri(treeUri),con);
+        if (volumePath == null) return File.separator;
+        if (volumePath.endsWith(File.separator))
+            volumePath = volumePath.substring(0, volumePath.length() - 1);
+
+        String documentPath = getDocumentPathFromTreeUri(treeUri);
+        if (documentPath.endsWith(File.separator))
+            documentPath = documentPath.substring(0, documentPath.length() - 1);
+
+        if (documentPath.length() > 0) {
+            if (documentPath.startsWith(File.separator))
+                return volumePath + documentPath;
+            else
+                return volumePath + File.separator + documentPath;
+        }
+        else return volumePath;
+    }
+
+
+    private static String getVolumePath(final String volumeId, Context context) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP)
+            return null;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R)
+            return getVolumePathForAndroid11AndAbove(volumeId, context);
+        else
+            return getVolumePathBeforeAndroid11(volumeId, context);
+    }
+
+
+    private static String getVolumePathBeforeAndroid11(final String volumeId, Context context){
+        try {
+            StorageManager mStorageManager = (StorageManager) context.getSystemService(Context.STORAGE_SERVICE);
+            Class<?> storageVolumeClazz = Class.forName("android.os.storage.StorageVolume");
+            Method getVolumeList = mStorageManager.getClass().getMethod("getVolumeList");
+            Method getUuid = storageVolumeClazz.getMethod("getUuid");
+            Method getPath = storageVolumeClazz.getMethod("getPath");
+            Method isPrimary = storageVolumeClazz.getMethod("isPrimary");
+            Object result = getVolumeList.invoke(mStorageManager);
+
+            final int length = Array.getLength(result);
+            for (int i = 0; i < length; i++) {
+                Object storageVolumeElement = Array.get(result, i);
+                String uuid = (String) getUuid.invoke(storageVolumeElement);
+                Boolean primary = (Boolean) isPrimary.invoke(storageVolumeElement);
+
+                if (primary && PRIMARY_VOLUME_NAME.equals(volumeId))    // primary volume?
+                    return (String) getPath.invoke(storageVolumeElement);
+
+                if (uuid != null && uuid.equals(volumeId))    // other volumes?
+                    return (String) getPath.invoke(storageVolumeElement);
+            }
+            // not found.
+            return null;
+        } catch (Exception ex) {
+            return null;
+        }
+    }
+
+    @TargetApi(Build.VERSION_CODES.R)
+    private static String getVolumePathForAndroid11AndAbove(final String volumeId, Context context) {
+        try {
+            StorageManager mStorageManager = (StorageManager) context.getSystemService(Context.STORAGE_SERVICE);
+            List<StorageVolume> storageVolumes = mStorageManager.getStorageVolumes();
+            for (StorageVolume storageVolume : storageVolumes) {
+                // primary volume?
+                if (storageVolume.isPrimary() && PRIMARY_VOLUME_NAME.equals(volumeId))
+                    return storageVolume.getDirectory().getPath();
+
+                // other volumes?
+                String uuid = storageVolume.getUuid();
+                if (uuid != null && uuid.equals(volumeId))
+                    return storageVolume.getDirectory().getPath();
+
+            }
+            // not found.
+            return null;
+        } catch (Exception ex) {
+            return null;
+        }
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    private static String getVolumeIdFromTreeUri(final Uri treeUri) {
+        final String docId = DocumentsContract.getTreeDocumentId(treeUri);
+        final String[] split = docId.split(":");
+        if (split.length > 0) return split[0];
+        else return null;
+    }
+
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    private static String getDocumentPathFromTreeUri(final Uri treeUri) {
+        final String docId = DocumentsContract.getTreeDocumentId(treeUri);
+        final String[] split = docId.split(":");
+        if ((split.length >= 2) && (split[1] != null)) return split[1];
+        else return File.separator;
+    }
+}


### PR DESCRIPTION
This is required to allow another apps to access files saved by SDL on the file system. Android protects access to app private folder, that's why all such files should be stored in a common place.