### PR TITLE
Fix invalid uses of erase while iterating through sets

### DIFF
--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_app_extension.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_app_extension.cc
@@ -88,7 +88,8 @@ void RCAppExtension::UnsubscribeFromInteriorVehicleData(
 void RCAppExtension::UnsubscribeFromInteriorVehicleDataOfType(
     const std::string& module_type) {
   bool unsubscribed = false;
-  for (auto& item : subscribed_interior_vehicle_data_) {
+  auto subscribed_ivi = subscribed_interior_vehicle_data_;
+  for (const auto& item : subscribed_ivi) {
     if (module_type == item.first) {
       subscribed_interior_vehicle_data_.erase(item);
       unsubscribed = true;

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/unsubscribe_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/unsubscribe_vehicle_data_request.cc
@@ -314,8 +314,8 @@ bool UnsubscribeVehicleDataRequest::CheckSubscriptionStatus(
 bool UnsubscribeVehicleDataRequest::UnsubscribePendingVehicleData(
     ApplicationSharedPtr app, const smart_objects::SmartObject& msg_params) {
   SDL_LOG_DEBUG("Unsubscribing from all pending VehicleData");
-
-  for (const auto& vi_name : vi_waiting_for_unsubscribe_) {
+  auto pending_vi = vi_waiting_for_unsubscribe_;
+  for (const auto& vi_name : pending_vi) {
     const auto converted_item = ConvertRequestToResponseName(vi_name);
     const bool is_unsubscription_successful =
         CheckSubscriptionStatus(converted_item, msg_params);

--- a/src/components/application_manager/src/display_capabilities_builder.cc
+++ b/src/components/application_manager/src/display_capabilities_builder.cc
@@ -157,7 +157,8 @@ bool DisplayCapabilitiesBuilder::IsWaitingForWindowCapabilities(
 void DisplayCapabilitiesBuilder::ResetDisplayCapabilities() {
   SDL_LOG_AUTO_TRACE();
   sync_primitives::AutoLock lock(display_capabilities_lock_);
-  for (auto& window_id : window_ids_to_resume_) {
+  auto window_ids = window_ids_to_resume_;
+  for (const auto& window_id : window_ids) {
     if (kDefaultWindowID != window_id) {
       window_ids_to_resume_.erase(window_id);
     }

--- a/src/components/application_manager/src/helpers/application_helper.cc
+++ b/src/components/application_manager/src/helpers/application_helper.cc
@@ -19,7 +19,7 @@ void DeleteWayPoints(ApplicationSharedPtr app,
 
 void DeleteCommands(ApplicationSharedPtr app, ApplicationManager& app_manager) {
   auto accessor = app->commands_map();
-  const auto& commands_map = accessor.GetData();
+  const auto commands_map = accessor.GetData();
 
   for (const auto& cmd : commands_map) {
     auto delete_UI_msg = MessageHelper::CreateDeleteUICommandRequest(
@@ -37,7 +37,7 @@ void DeleteCommands(ApplicationSharedPtr app, ApplicationManager& app_manager) {
 
 void DeleteSubmenus(ApplicationSharedPtr app, ApplicationManager& app_manager) {
   auto accessor = app->sub_menu_map();
-  const auto& sub_menu_map = accessor.GetData();
+  const auto sub_menu_map = accessor.GetData();
 
   for (const auto& smenu : sub_menu_map) {
     MessageHelper::SendDeleteSubmenuRequest(smenu.second, app, app_manager);
@@ -48,7 +48,7 @@ void DeleteSubmenus(ApplicationSharedPtr app, ApplicationManager& app_manager) {
 void DeleteChoiceSets(ApplicationSharedPtr app,
                       ApplicationManager& app_manager) {
   auto accessor = app->choice_set_map();
-  const auto& choices = accessor.GetData();
+  const auto choices = accessor.GetData();
 
   for (const auto& choice : choices) {
     MessageHelper::SendDeleteChoiceSetRequest(choice.second, app, app_manager);

--- a/src/components/application_manager/src/resumption/resumption_data_processor_impl.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_processor_impl.cc
@@ -534,7 +534,7 @@ void ResumptionDataProcessorImpl::DeleteSubmenus(
       application->app_id(), resumption_status_, resumption_status_lock_);
 
   auto accessor = application->sub_menu_map();
-  const auto& sub_menu_map = accessor.GetData();
+  const auto sub_menu_map = accessor.GetData();
 
   for (const auto& smenu : sub_menu_map) {
     auto failed_submenu_request =
@@ -627,7 +627,7 @@ void ResumptionDataProcessorImpl::DeleteCommands(
   };
 
   auto accessor = application->commands_map();
-  const auto& commands_map = accessor.GetData();
+  const auto commands_map = accessor.GetData();
 
   for (const auto& cmd : commands_map) {
     const auto cmd_id = extract_cmd_id(cmd.second);
@@ -719,7 +719,7 @@ void ResumptionDataProcessorImpl::DeleteChoicesets(
       application->app_id(), resumption_status_, resumption_status_lock_);
 
   auto accessor = application->choice_set_map();
-  const auto& choices = accessor.GetData();
+  const auto choices = accessor.GetData();
   for (const auto& choice : choices) {
     auto failed_choice_set =
         FindResumptionChoiceSetRequest(choice.first, failed_requests);
@@ -881,7 +881,7 @@ void ResumptionDataProcessorImpl::DeleteButtonsSubscriptions(
   SDL_LOG_AUTO_TRACE();
   const ButtonSubscriptions button_subscriptions =
       application->SubscribedButtons().GetData();
-  for (auto& btn : button_subscriptions) {
+  for (const auto& btn : button_subscriptions) {
     const auto hmi_btn = static_cast<hmi_apis::Common_ButtonName::eType>(btn);
     if (hmi_apis::Common_ButtonName::CUSTOM_BUTTON == hmi_btn) {
       continue;


### PR DESCRIPTION
Fix https://adc.luxoft.com/jira/browse/FORDTCN-12440

* Fix invalid use of erase while iterating through VI set

Copies the contents of `vi_waiting_for_unsubscribe_` and iterate through the copy to prevent editing the container while iterating

* Fix invalid iterators in application helper and rc app extension

* Fix invalid iterators in resumption data processor

* Fix invalid iterator in display capabilities builder