### PR TITLE
Make BLE device disconnect properly

### DIFF
--- a/src/components/transport_manager/include/transport_manager/bluetooth_le/bluetooth_le_transport_adapter.h
+++ b/src/components/transport_manager/include/transport_manager/bluetooth_le/bluetooth_le_transport_adapter.h
@@ -63,6 +63,9 @@ class BluetoothLeTransportAdapter : public TransportAdapterImpl {
 
   void SearchDeviceDone(const DeviceVector& devices) override;
 
+  void DisconnectDone(const DeviceUID& device_handle,
+                      const ApplicationHandle& app_handle) override;
+
   private:
     DeviceUID ble_active_device_uid_;
     ApplicationHandle ble_app_handle_;

--- a/src/components/transport_manager/src/bluetooth_le/bluetooth_le_device_scanner.cc
+++ b/src/components/transport_manager/src/bluetooth_le/bluetooth_le_device_scanner.cc
@@ -121,14 +121,17 @@ void BluetoothLeDeviceScanner::ProcessMessage(const std::vector<uint8_t>& data) 
       case BleProtocolActions::ON_DEVICE_DISCONNECTED:
       {
         const auto addr = BleControlProtocol::GetAddress(data);
-        auto remove_result = std::remove_if(found_devices_with_sdl_.begin(), 
-        found_devices_with_sdl_.end(), [&addr](DeviceSptr d){
-          
+        auto it_device = std::find_if(found_devices_with_sdl_.begin(),
+                                      found_devices_with_sdl_.end(), [&addr](DeviceSptr d){
           BluetoothLeDevice tDevice(addr, "");
           return d->IsSameAs(static_cast<Device*>(&tDevice));
         });
 
-        found_devices_with_sdl_.erase(remove_result, found_devices_with_sdl_.end());
+        if (it_device != found_devices_with_sdl_.end()) {
+          DeviceSptr device = *it_device;
+          found_devices_with_sdl_.erase(it_device);
+          controller_->DisconnectDone(device->unique_device_id(), 0);
+        }
       }
       break;
 

--- a/src/components/transport_manager/src/bluetooth_le/bluetooth_le_transport_adapter.cc
+++ b/src/components/transport_manager/src/bluetooth_le/bluetooth_le_transport_adapter.cc
@@ -100,6 +100,23 @@ void BluetoothLeTransportAdapter::SearchDeviceDone(const DeviceVector& devices) 
     TransportAdapterImpl::SearchDeviceDone(devices);
 }
 
+void BluetoothLeTransportAdapter::DisconnectDone(const DeviceUID& device_handle,
+                                                 const ApplicationHandle& app_handle) {
+    if (ble_active_device_uid_ == device_handle ) {
+        const auto disconnect_result =
+                TransportAdapterImpl::Disconnect(ble_active_device_uid_, ble_app_handle_);
+        if (TransportAdapter::OK == disconnect_result) {
+            TransportAdapterImpl::DisconnectDone(ble_active_device_uid_, ble_app_handle_);
+            ble_active_device_uid_.clear();
+            ble_app_handle_ = 0;
+        }
+
+        return;
+    }
+
+    TransportAdapterImpl::DisconnectDone(device_handle, app_handle);
+}
+
 bool BluetoothLeTransportAdapter::ToBeAutoConnected(DeviceSptr device) const {
     if (!ble_active_device_uid_.empty()) {
         // BLE device connection is established on the Java side

--- a/src/components/transport_manager/src/transport_adapter/transport_adapter_impl.cc
+++ b/src/components/transport_manager/src/transport_adapter/transport_adapter_impl.cc
@@ -1253,8 +1253,9 @@ void TransportAdapterImpl::RemoveDevice(const DeviceUID& device_handle) {
   DeviceMap::iterator i = devices_.find(device_handle);
   if (i != devices_.end()) {
     DeviceSptr device = i->second;
-    bool is_cloud_device = (GetDeviceType() == DeviceType::CLOUD_WEBSOCKET);
-    if (!device->keep_on_disconnect() || is_cloud_device) {
+    const bool is_cloud_device = (GetDeviceType() == DeviceType::CLOUD_WEBSOCKET);
+    const bool is_ble_device = (GetDeviceType() == DeviceType::BLUETOOTH_LE);
+    if (!device->keep_on_disconnect() || is_cloud_device || is_ble_device) {
       devices_.erase(i);
       for (TransportAdapterListenerList::iterator it = listeners_.begin();
            it != listeners_.end();


### PR DESCRIPTION
There was an issue that SDL does not remove the BLE device information from the list in case of disconnection.
This fix allows to remove BLE device connection and shutdown its client and server instances and also removes the device descriptor from the transport manager so HMI will receive a proper `UpdateDeviceList` request after disconnect. 