### PR TITLE
workaround with logger re-init

### DIFF
--- a/src/appMain/android_platform_interface.cc
+++ b/src/appMain/android_platform_interface.cc
@@ -55,9 +55,12 @@ jint JNI_OnLoad(JavaVM* vm, void*) {
 
 void StartSDLNative(JNIEnv* env, jobject) {
 #ifdef ENABLE_LOG
+  static bool __inited_log = false;
   auto logger_impl =
       std::unique_ptr<logger::LoggerImpl>(new logger::LoggerImpl());
-  logger::Logger::instance(logger_impl.get());
+  if (!__inited_log) {
+    logger::Logger::instance(logger_impl.get());
+  }
 #endif  // ENABLE_LOG
   const std::string internal_storage =
       JNI_GetMainActivityStringProperty("sdl_cache_folder_path");
@@ -76,12 +79,15 @@ void StartSDLNative(JNIEnv* env, jobject) {
   profile_instance.set_config_file_name(ini_name);
 
 #ifdef ENABLE_LOG
-  if (profile_instance.logs_enabled()) {
-    // Logger initialization
-    // Redefine for each paticular logger implementation
-    auto logger =
-        std::unique_ptr<logger::AndroidLogger>(new logger::AndroidLogger());
-    logger_impl->Init(std::move(logger));
+  if (!__inited_log) {
+    if (profile_instance.logs_enabled()) {
+      // Logger initialization
+      // Redefine for each paticular logger implementation
+      auto logger =
+              std::unique_ptr<logger::AndroidLogger>(new logger::AndroidLogger());
+      logger_impl->Init(std::move(logger));
+    }
+    __inited_log = true;
   }
 #endif
 

--- a/src/components/utils/src/logger/logger_impl.cc
+++ b/src/components/utils/src/logger/logger_impl.cc
@@ -36,8 +36,6 @@
 
 namespace logger {
 
-Logger* Logger::instance_ = nullptr;
-
 LoggerImpl::LoggerImpl(bool use_message_loop_thread)
     : impl_(nullptr), use_message_loop_thread_(use_message_loop_thread) {}
 
@@ -70,8 +68,6 @@ void LoggerImpl::DeInit() {
   if (impl_) {
     impl_->DeInit();
   }
-
-  instance_ = nullptr;
 }
 
 void LoggerImpl::Flush() {
@@ -100,6 +96,7 @@ void LoggerImpl::PushLog(const LogMessage& log_message) {
 }
 
 Logger& Logger::instance(Logger* pre_init) {
+  static Logger* instance_;
   if (pre_init) {
     assert(instance_ == nullptr);
     instance_ = pre_init;


### PR DESCRIPTION
For avoid some crashes on restart SDL core